### PR TITLE
Add uf constraints

### DIFF
--- a/src/set_relation/expression.h
+++ b/src/set_relation/expression.h
@@ -87,6 +87,9 @@ public:
     //! Get the coefficient of this term.
     int coefficient() const { return mCoeff; }
     
+    //! Set the coefficient of this term.
+    void setCoefficient(int coeff) { mCoeff = coeff; }
+    
     //! Returns true if the Term is really a UFCallTerm.
     virtual bool isUFCall() const { return false; }
 

--- a/src/set_relation/expression.h
+++ b/src/set_relation/expression.h
@@ -258,6 +258,9 @@ public:
 
     //! Returns the function name as a string.
     std::string name() const { return mFuncName; }
+    
+    //! Enables the function name to be set.
+    void setName(std::string n) { mFuncName = n; }
 
     //! Return a new Exp with all nested functions such as
     //! f ( f_inv ( i ) ) changed to i.

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -1761,6 +1761,30 @@ Set* Conjunction::normalizeR() const
 
 }
 
+// FIXME?: Right now doing this all within an individual conjunct.
+// We need to put in the same constraints across conjuncts to be more
+// general.
+void Conjunction::addUFConstraintsHelper(std::string uf1str, 
+                                         std::string opstr, std::string uf2str){
+
+
+
+/*
+    for (std::list<Exp*>::iterator i=mEqualities.begin();
+                i != mEqualities.end(); i++) {
+        delete (*i);
+    }
+    mEqualities.clear();
+
+    for (std::list<Exp*>::iterator i=mInequalities.begin();
+                i != mInequalities.end(); i++) {
+        delete (*i);
+    }
+    mInequalities.clear();
+*/
+}
+
+
 
 /******************************************************************************/
 #pragma mark -
@@ -2119,6 +2143,15 @@ void SparseConstraints::remapTupleVars(const std::vector<int>& oldToNewLocs) {
     }
 }
 
+void SparseConstraints::addUFConstraintsHelper(std::string uf1str, 
+                            std::string opstr, std::string uf2str) {
+    for (std::list<Conjunction*>::iterator iter=mConjunctions.begin();
+            iter != mConjunctions.end(); iter++) {
+        (*iter)->addUFConstraintsHelper(uf1str,opstr,uf2str);
+    }
+}
+
+
 /******************************************************************************/
 #pragma mark -
 
@@ -2281,8 +2314,10 @@ Set* Set::boundTupleExp(const TupleExpTerm& tuple_exp) const {
 
 Set* Set::addUFConstraints(std::string uf1str, 
                            std::string opstr, std::string uf2str) {
-    // FIXME: Not implemented yet.
-    return new Set(*this);
+    
+    Set* retval = new Set(*this);
+    retval->addUFConstraintsHelper(uf1str,opstr,uf2str);
+    return retval;
 }
 
 /******************************************************************************/
@@ -2618,8 +2653,9 @@ void Relation::normalize() {
 
 Relation* Relation::addUFConstraints(std::string uf1str, 
                                      std::string opstr, std::string uf2str) {
-    // FIXME: Not implemented yet.
-    return new Relation(*this);
+    Relation* retval = new Relation(*this);
+    retval->addUFConstraintsHelper(uf1str,opstr,uf2str);
+    return retval;
 }
             
 

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -265,11 +265,6 @@ public:
     //Set* createAffineSuperSet(UFCallMapAndBounds & ufcallmap);
     void ufCallsToTempVars(UFCallMapAndBounds & ufcallmap);
     
-    /*! Helper for addUFConstraints.
-    */
-    void addUFConstraintsHelper(std::string uf1str, 
-                                std::string opstr, std::string uf2str);
-
     /*! Returns a normalized Set that represents this Conjunct.
     **  It has to be a set because bounds on parameters and UF calls
     **  can introduce disjunctions.
@@ -420,18 +415,6 @@ public:
 
 
   protected:
-    /*! For adding constraints involving uninterpreted functions.
-    **  For example, if forall e, index(e)<=diagptr(e), then
-    **  this method will find all instances of index() and diagptr()
-    **  in the current constraints and using the current parameters
-    **  add in the provided constraint.  Let's say that diagptr is
-    **  called with diagptr(foo) and diagptr(x+1) and index is called
-    **  with index(y).  Then the following constraints will be added
-    **      index(foo)<=diagptr(foo)
-    **      index(x+1)<=diagptr(x+1)
-    **      index(y)<=diagptr(y)
-    **  Makes changes to the current SparseConstraints object.
-    */
     void addUFConstraintsHelper(std::string uf1str, 
                                 std::string opstr, std::string uf2str);
 

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -265,6 +265,11 @@ public:
     */
     //Set* createAffineSuperSet(UFCallMapAndBounds & ufcallmap);
     void ufCallsToTempVars(UFCallMapAndBounds & ufcallmap);
+    
+    /*! Helper for addUFConstraints.
+    */
+    void addUFConstraintsHelper(std::string uf1str, 
+                                std::string opstr, std::string uf2str);
 
     /*! Returns a normalized Set that represents this Conjunct.
     **  It has to be a set because bounds on parameters and UF calls

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3421,3 +3421,17 @@ TEST_F(SetRelationTest, VisitorDebugTest){
     delete s;
 }
 
+#pragma mark addUFConstraintsTest
+TEST_F(SetRelationTest, addUFConstraintsTest){
+    Set* s = new Set("{[i,j] : index(i) <= j && j < index(i+1)}");
+    
+    Set* result = s->addUFConstraints("index","<=", "diagptr");
+    
+    EXPECT_EQ("{ [i, j] : j - index(i) >= 0 && -diagptr(i) + index(i) >= 0 "
+              "&& diagptr(i + 1) - index(i + 1) >= 0 && -j + index(i + 1) - "
+              "1 >= 0 }",
+              result->prettyPrintString());
+              
+    delete s;
+    delete result;    
+}

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3423,15 +3423,45 @@ TEST_F(SetRelationTest, VisitorDebugTest){
 
 #pragma mark addUFConstraintsTest
 TEST_F(SetRelationTest, addUFConstraintsTest){
+  {
     Set* s = new Set("{[i,j] : index(i) <= j && j < index(i+1)}");
-    
     Set* result = s->addUFConstraints("index","<=", "diagptr");
     
-    EXPECT_EQ("{ [i, j] : j - index(i) >= 0 && -diagptr(i) + index(i) >= 0 "
+    EXPECT_EQ("{ [i, j] : j - index(i) >= 0 && diagptr(i) - index(i) >= 0 "
               "&& diagptr(i + 1) - index(i + 1) >= 0 && -j + index(i + 1) - "
               "1 >= 0 }",
               result->prettyPrintString());
-              
+
     delete s;
-    delete result;    
+    delete result;
+  }
+
+  {
+    Relation* r = new Relation("{[i,j]->[k] : index(i) <= j && "
+        "j < index(i+1) && diagptr(v+1)<k && k<indexptr(i)}");
+    
+    Relation* result1 = r->addUFConstraints("index",">", "diagptr");
+    
+    EXPECT_EQ("{ [i, j] -> [k] : j - index(i) >= 0 && -j + index(i + 1) "
+              "- 1 >= 0 && -k + indexptr(i) - 1 >= 0 && k - diagptr(v + "
+              "1) - 1 >= 0 && -diagptr(i) + index(i) + 1 >= 0 && -diagpt"
+              "r(i + 1) + index(i + 1) + 1 >= 0 && -diagptr(v + 1) + ind"
+              "ex(v + 1) + 1 >= 0 }",
+              result1->prettyPrintString());
+
+    Relation* result2 = r->addUFConstraints("index","=", "diagptr");
+
+    EXPECT_EQ("{ [i, j] -> [k] : diagptr(i) - index(i) = 0 && diagptr(i + "
+              "1) - index(i + 1) = 0 && diagptr(v + 1) - index(v + 1) = 0 "
+              "&& j - index(i) >= 0 && -j + index(i + 1) - 1 >= 0 && -k + "
+              "indexptr(i) - 1 >= 0 && k - diagptr(v + 1) - 1 >= 0 }",
+              result2->prettyPrintString());
+
+    
+    delete r;
+    delete result1;
+    delete result2;
+  }
+ 
+              
 }


### PR DESCRIPTION
For adding constraints involving uninterpreted functions.  For example, if forall e, index(e)<=diagptr(e), then this method will find all instances of index() and diagptr() in the current constraints and using the current parameters add in the provided constraint.  Let's say that diagptr is called with diagptr(foo) and diagptr(x+1) and index is called with index(y).  Then the following constraints will be added

```
  index(foo)<=diagptr(foo)

  index(x+1)<=diagptr(x+1)

  index(y)<=diagptr(y)
```

Makes changes to the current SparseConstraints object and uses the Visitor design pattern.  See test cases in set_relation_test.cc under addUFConstraintsTest.
