### PR TITLE
boundDomainRange

### DIFF
--- a/src/set_relation/UFCallMap.h
+++ b/src/set_relation/UFCallMap.h
@@ -44,6 +44,16 @@ public:
     //! Assignment operator.
     UFCallMap& operator=( const UFCallMap& other );
 
+    //! Returns a iterator to the first element in mUFC2Str map
+    inline std::map<UFCallTerm,string>::iterator begin(){
+        return (mUFC2Str.begin());
+    }
+
+    //! Returns a iterator to the last element in mUFC2Str map
+    inline std::map<UFCallTerm,string>::iterator end(){
+        return (mUFC2Str.end());
+    }
+
     //! returns a string representing ufcterm as a symbolic constant
     string symUFC( std::string &ufcName );
 

--- a/src/set_relation/UFCallMap.h
+++ b/src/set_relation/UFCallMap.h
@@ -44,16 +44,6 @@ public:
     //! Assignment operator.
     UFCallMap& operator=( const UFCallMap& other );
 
-    //! Returns a iterator to the first element in mUFC2Str map
-    inline std::map<UFCallTerm,string>::iterator begin(){
-        return (mUFC2Str.begin());
-    }
-
-    //! Returns a iterator to the last element in mUFC2Str map
-    inline std::map<UFCallTerm,string>::iterator end(){
-        return (mUFC2Str.end());
-    }
-
     //! returns a string representing ufcterm as a symbolic constant
     string symUFC( std::string &ufcName );
 

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3439,8 +3439,9 @@ class VisitorBoundDomainRange : public Visitor {
          Set* addedConstSet;
          int in_ar;
   public:
+         //! For each UFC adds Domain & Range constraints to addedConstSet
          void preVisitUFCallTerm(UFCallTerm * t);
-         //! Initials addedConstSet and in_ar for c
+         //! Initials addedConstSet and in_ar for each c
          void preVisitConjunction(iegenlib::Conjunction * c);
          //! Adds in all of the gathered constraints in addedConstSet for c
          void postVisitConjunction(iegenlib::Conjunction * c);

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3429,4 +3429,144 @@ UFCallMap* SparseConstraints::mapUFCtoSym()
     return (v->getMap());
 }
 
+/*****************************************************************************/
+#pragma mark -
+/*************** VisitorBoundDomainRange *****************************/
+// Vistor Class used in 
+// Vistor Class used in traversing conjunctions for finding UFCalls
+class VisitorBoundDomainRange : public Visitor {
+  private:
+         UFCallMap* ufcmap;
+          
+  public:
+         VisitorBoundDomainRange (UFCallMap* imap) { ufcmap = imap; }
+         void preVisitConjunction(iegenlib::Conjunction * c);
+};
+
+void VisitorBoundDomainRange::preVisitConjunction(Conjunction* c){
+
+    int in = c->inarity();
+    c->setinarity(0);
+    Set* newSet = new Set(c->prettyPrintString());
+
+    //!  Iterating over all UFCalls
+    for(std::map<UFCallTerm,string>::iterator it  = ufcmap->begin();
+                                              it != ufcmap->end(); it++){
+        const UFCallTerm* uf_call = &(it->first);
+
+
+        //! Bounding argument expressions of UFCalls by their domain, 
+        //  and adding them as inequalities to constraints set
+        {
+        // Create a TupleExpTerm from the parameter expressions.
+        TupleExpTerm tuple_exp(uf_call->numArgs());
+        for (unsigned int count=0; count<uf_call->numArgs(); count++) {
+            tuple_exp.setExpElem(count, uf_call->getParamExp(count)->clone());
+        }
+
+        // look up bound for uninterpreted function
+        Set* domain = iegenlib::queryDomainCurrEnv(uf_call->name());
+
+        // have the domain create the constraints and store those constraints
+        Set* constraintSet = domain->boundTupleExp(tuple_exp);
+
+        // The constraintSet returned by boundTupleExp will not have any
+        // tuple variables. We want the tuple variable declaration to line up.
+        constraintSet->setTupleDecl( newSet->getTupleDecl() );
+    
+        // Intersect the new set of constraints with the existing constraints.
+        Set* mCC = newSet;     // pointer to current set
+        newSet = mCC->Intersect(constraintSet);
+    
+        delete mCC; // cleanup old guy
+        delete constraintSet;
+        delete domain;
+        }
+
+        //! Bounding UFCalls by their range, 
+        //  and adding them as inequalities to constraints set
+        {
+        // look up range for uninterpreted function
+        Set* range = iegenlib::queryRangeCurrEnv(uf_call->name());
+    
+        // Assuming that uf call and its range align.
+        if (! uf_call->isIndexed() 
+            && ((unsigned)range->arity() != uf_call->size()) ) {
+            throw assert_exception("Set::boundDomainRange: "
+            "ufcall returning fewer dimensions than declared range");
+        }
+
+        // For each dimension of the return value create a instance
+        TupleExpTerm tuple_exp(uf_call->size());
+    
+        // Determine what the output arity of this particular UF call is
+        // taking into consideration that it could be indexed.
+        unsigned int out_arity = range->arity();
+        if (uf_call->isIndexed()) {
+            out_arity = 1; // only one element is being accessed
+        } 
+
+        for (unsigned int i=0; i<out_arity; i++) {    
+            // Create a temporary variable and maintain correspondence 
+            // with UFCallTerm.  Add one more tuple var to constraints.
+            UFCallTerm* indexed_uf_call;
+            if (out_arity==1) {
+                indexed_uf_call = new UFCallTerm(*uf_call);
+            } else {
+                indexed_uf_call = new UFCallTerm(*uf_call);
+                indexed_uf_call->setTupleIndex( i );
+            }
+        
+            // Create a TupleExpTerm from the new temporary var.
+            Exp* tuple_var_exp = new Exp();
+            tuple_var_exp->addTerm(indexed_uf_call);
+            tuple_exp.setExpElem(i,tuple_var_exp);   
+        }
+
+        // have the range create the constraints and store those constraints
+        Set* constraintSet = range->boundTupleExp(tuple_exp);
+
+        // Same as Domain
+        constraintSet->setTupleDecl( newSet->getTupleDecl() );
+    
+        // Intersect the new set of constraints with the existing constraints.
+        Set* mCC = newSet;     // pointer to current set
+        newSet = mCC->Intersect(constraintSet);
+
+        delete mCC;
+        delete constraintSet;
+        delete range;
+        }
+    }
+
+    Conjunction* res = new 
+                     Conjunction(*(newSet->mConjunctions.front()));
+    *c = *res;
+    c->setinarity(in);
+
+    delete res;
+    delete newSet;
+}
+
+Set* Set::boundDomainRange(UFCallMap* ufcmap)
+{
+    Set* s = new Set(*this);
+    VisitorBoundDomainRange *v = new VisitorBoundDomainRange(ufcmap);
+    
+    s->acceptVisitor(v);
+
+    return s;
+}
+
+Relation* Relation::boundDomainRange(UFCallMap* ufcmap)
+{
+    Relation* r = new Relation(*this);
+    VisitorBoundDomainRange *v = new VisitorBoundDomainRange(ufcmap);
+    
+    r->acceptVisitor(v);
+
+    return r;
+}
+
+
 }//end namespace iegenlib

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3432,8 +3432,9 @@ UFCallMap* SparseConstraints::mapUFCtoSym()
 /*****************************************************************************/
 #pragma mark -
 /*************** VisitorBoundDomainRange *****************************/
-// Vistor Class used in 
-// Vistor Class used in traversing conjunctions for finding UFCalls
+// Vistor Class used in BoundDomain Range
+// Vistor Class used in traversing conjunctions for adding constarints due to
+// Domain and Range of UFCalls
 class VisitorBoundDomainRange : public Visitor {
   private:
          UFCallMap* ufcmap;
@@ -3548,6 +3549,8 @@ void VisitorBoundDomainRange::preVisitConjunction(Conjunction* c){
     delete newSet;
 }
 
+//! Adds constraints due to domain and range of all UFCalls in UFCallmap
+//  Users own the returned Set object.
 Set* Set::boundDomainRange(UFCallMap* ufcmap)
 {
     Set* s = new Set(*this);
@@ -3558,6 +3561,8 @@ Set* Set::boundDomainRange(UFCallMap* ufcmap)
     return s;
 }
 
+//! Adds constraints due to domain and range of all UFCalls in UFCallmap
+//  Users own the returned Relation object.
 Relation* Relation::boundDomainRange(UFCallMap* ufcmap)
 {
     Relation* r = new Relation(*this);
@@ -3567,6 +3572,5 @@ Relation* Relation::boundDomainRange(UFCallMap* ufcmap)
 
     return r;
 }
-
 
 }//end namespace iegenlib

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -419,6 +419,7 @@ public:
     // a pointer to final UFCallMap that the user is responsible for deleting.
     UFCallMap* mapUFCtoSym();
 
+
 // FIXME: what methods should we have to iterate over conjunctions so
 // this can go back to protected?
 //protected:
@@ -531,6 +532,10 @@ public:
     
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);    
+
+    //! Adds constraints due to domain and range of all UFCall in UFCallmap
+    //  Users own the returned Set object.
+    Set* boundDomainRange(UFCallMap* ufcmap);
 
     //  Projects out tuple varrable No. tvar
     Set* projectOut(int tvar);
@@ -671,6 +676,10 @@ public:
 
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);
+
+    //! Adds constraints due to domain and range of all UFCall in UFCallmap
+    //  Users own the returned Set object.
+    Relation* boundDomainRange(UFCallMap* ufcmap);
 
     // Projects out tuple varrable No. tvar
     Relation* projectOut(int tvar);

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -535,7 +535,7 @@ public:
 
     //! Adds constraints due to domain and range of all UFCalls in UFCallmap
     //  Users own the returned Set object.
-    Set* boundDomainRange(UFCallMap* ufcmap);
+    Set* boundDomainRange();
 
     //  Projects out tuple varrable No. tvar
     Set* projectOut(int tvar);
@@ -679,7 +679,7 @@ public:
 
     //! Adds constraints due to domain and range of all UFCalls in UFCallmap
     //  Users own the returned Relation object.
-    Relation* boundDomainRange(UFCallMap* ufcmap);
+    Relation* boundDomainRange();
 
     // Projects out tuple varrable No. tvar
     Relation* projectOut(int tvar);

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -533,7 +533,7 @@ public:
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);    
 
-    //! Adds constraints due to domain and range of all UFCall in UFCallmap
+    //! Adds constraints due to domain and range of all UFCalls in UFCallmap
     //  Users own the returned Set object.
     Set* boundDomainRange(UFCallMap* ufcmap);
 
@@ -677,8 +677,8 @@ public:
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);
 
-    //! Adds constraints due to domain and range of all UFCall in UFCallmap
-    //  Users own the returned Set object.
+    //! Adds constraints due to domain and range of all UFCalls in UFCallmap
+    //  Users own the returned Relation object.
     Relation* boundDomainRange(UFCallMap* ufcmap);
 
     // Projects out tuple varrable No. tvar

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3784,3 +3784,79 @@ TEST_F(SetRelationTest, mapUFCtoSym) {
     delete map;
 }
 
+
+#pragma mark boundDomainRange
+//Testing boundDomainRange: bounding by domain and range of UFCalls
+TEST_F(SetRelationTest, boundDomainRange) {
+
+    iegenlib::setCurrEnv();
+    iegenlib::appendCurrEnv("col",
+        new Set("{[i]:0<=i &&i<m}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+    iegenlib::appendCurrEnv("idx",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<m}"), true, iegenlib::Monotonic_NONE);
+
+    Set *s = new Set("[n] -> { [i,j,ip,jp] : i = col(jp) "
+       "and i < ip and 0 <= i and i < n and idx(i) <= j and j < idx(i+1) "
+         "and 0 <= ip and ip < n and idx(ip) <= jp and jp < idx(ip+1) }");
+
+    Set *ex_s = new Set("{ [i, j, ip, jp] : i - col(jp) = 0 && i >= 0 &&"
+                  " ip >= 0 && jp >= 0 && col(jp) >= 0 && idx(i) >= 0 &&"
+  " idx(i + 1) >= 0 && idx(ip) >= 0 && idx(ip + 1) >= 0 && i + 1 >= 0 &&"
+                " j - idx(i) >= 0 && ip + 1 >= 0 && jp - idx(ip) >= 0 &&"
+             " -i + ip - 1 >= 0 && -i + n - 2 >= 0 && -i + n - 1 >= 0 &&"
+   " -j + idx(i + 1) - 1 >= 0 && -ip + n - 2 >= 0 && -ip + n - 1 >= 0 &&"
+          " -jp + m - 1 >= 0 && -jp + idx(ip + 1) - 1 >= 0 && m - idx(i)"
+      " - 1 >= 0 && m - idx(i + 1) - 1 >= 0 && m - idx(ip) - 1 >= 0 && m"
+                      " - idx(ip + 1) - 1 >= 0 && n - col(jp) - 1 >= 0 }");
+
+    Relation* r = new Relation("[n] -> { [i,j] -> [ip,jp] : i = col(jp) "
+       "and i < ip and 0 <= i and i < n and idx(i) <= j and j < idx(i+1) "
+         "and 0 <= ip and ip < n and idx(ip) <= jp and jp < idx(ip+1) }");
+
+    Relation *ex_r = new Relation("{ [i, j] -> [ip, jp] : i - col(jp) = "
+    "0 && i >= 0 && ip >= 0 && jp >= 0 && col(jp) >= 0 && idx(i) >= 0 &&"
+  " idx(i + 1) >= 0 && idx(ip) >= 0 && idx(ip + 1) >= 0 && i + 1 >= 0 &&"
+                " j - idx(i) >= 0 && ip + 1 >= 0 && jp - idx(ip) >= 0 &&"
+             " -i + ip - 1 >= 0 && -i + n - 2 >= 0 && -i + n - 1 >= 0 &&"
+   " -j + idx(i + 1) - 1 >= 0 && -ip + n - 2 >= 0 && -ip + n - 1 >= 0 &&"
+          " -jp + m - 1 >= 0 && -jp + idx(ip + 1) - 1 >= 0 && m - idx(i)"
+      " - 1 >= 0 && m - idx(i + 1) - 1 >= 0 && m - idx(ip) - 1 >= 0 && m"
+                      " - idx(ip + 1) - 1 >= 0 && n - col(jp) - 1 >= 0 }");
+
+
+    //!  ----------------   Testing boundDomainRange for Set ------------
+    iegenlib::UFCallMap *mapS;
+
+    // ---------        Geting a map of UFCalls    ---------------
+    mapS = s->mapUFCtoSym();
+
+    Set* ns = s->boundDomainRange(mapS);
+//    std::cout<<std::endl<<ns->prettyPrintString()<<std::endl;
+
+    EXPECT_EQ( ex_s->prettyPrintString() , ns->prettyPrintString() );
+
+    //!  ----------------   Testing boundDomainRange for Relation -------
+    iegenlib::UFCallMap *mapR;
+
+    // ---------        Geting a map of UFCalls    ---------------
+    mapR = r->mapUFCtoSym();
+
+    Relation* nr = r->boundDomainRange(mapR);
+//    std::cout<<std::endl<<nr->prettyPrintString()<<std::endl;
+
+    EXPECT_EQ( ex_r->prettyPrintString() , nr->prettyPrintString() );
+
+
+    delete s;
+    delete ex_s;
+    delete ns;
+    delete mapS;
+    delete r;
+    delete ex_r;
+    delete nr;
+    delete mapR;
+}
+
+

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3827,23 +3827,16 @@ TEST_F(SetRelationTest, boundDomainRange) {
 
 
     //!  ----------------   Testing boundDomainRange for Set ------------
-    iegenlib::UFCallMap *mapS;
 
-    // ---------        Geting a map of UFCalls    ---------------
-    mapS = s->mapUFCtoSym();
-
-    Set* ns = s->boundDomainRange(mapS);
+    Set* ns = s->boundDomainRange();
 //    std::cout<<std::endl<<ns->prettyPrintString()<<std::endl;
 
     EXPECT_EQ( ex_s->prettyPrintString() , ns->prettyPrintString() );
 
+
     //!  ----------------   Testing boundDomainRange for Relation -------
-    iegenlib::UFCallMap *mapR;
 
-    // ---------        Geting a map of UFCalls    ---------------
-    mapR = r->mapUFCtoSym();
-
-    Relation* nr = r->boundDomainRange(mapR);
+    Relation* nr = r->boundDomainRange();
 //    std::cout<<std::endl<<nr->prettyPrintString()<<std::endl;
 
     EXPECT_EQ( ex_r->prettyPrintString() , nr->prettyPrintString() );
@@ -3852,10 +3845,8 @@ TEST_F(SetRelationTest, boundDomainRange) {
     delete s;
     delete ex_s;
     delete ns;
-    delete mapS;
     delete r;
     delete ex_r;
     delete nr;
-    delete mapR;
 }
 

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3859,4 +3859,3 @@ TEST_F(SetRelationTest, boundDomainRange) {
     delete mapR;
 }
 
-


### PR DESCRIPTION
boundDomainRange functionality is added.

This is implemented as functions in Set and Relation. They return Set or Relation, so they cannot be at SparseConstraints. We use visitor to traverse conjunctions and UFCalls, and add constraints that are due to bound and Range information from UFCalls. 
