### PR TITLE
added reverseAffineSubstitution

### DIFF
--- a/src/set_relation/UFCallMap.cc
+++ b/src/set_relation/UFCallMap.cc
@@ -62,13 +62,18 @@ string UFCallMap::symUFC( std::string &ufcName )
     return (ss.str());
 }
 
-//! Inserts a UFC term to both of themaps.
-//  The function creates an string representing the UFC as symbolic constant,
-//  then, adds (ufc,vt) & (vt,ufc) to mUFC2VarParam & mVarParam2UFC
-//  It does not add repetitive UFCs. The function does not own ufcterm.
+/*! Use this to insert a UFCallTerm to map.
+**  The function creates an VarTerm representing the UFC then,
+**  adds (ufc,vt) to mUFC2VarParam & adds (vt,str) to mVarParam2UFC
+**  The class does not own the object pointed by ufcterm,
+**  and it is left unchanged.
+**
+**  NOTE: The function ignores coefficient of the UFCallTerm.
+**        So, -2*row(i)  is considered as just row(i)
+*/
 void UFCallMap::insert( UFCallTerm *ufc )
 {
-    UFCallTerm* ufcterm = ( (UFCallTerm*)(ufc->clone()) );
+    UFCallTerm* ufcterm = new UFCallTerm (*ufc);
     ufcterm->setCoefficient(1);
     if( find(ufcterm) ){
         return;
@@ -84,11 +89,17 @@ void UFCallMap::insert( UFCallTerm *ufc )
     delete ufcterm;
 }
 
-//! Searches for ufcterm in mUFC2VarParam. If it exists in the map, returns
-// the equ. symbol, otherwise returns an empty string.
+/*! Searches for ufcterm in the map. If ufcterm exists, it returns
+**  a pointer to equ. VarTerm, otherwise returns NULL.
+**  The class does not own the object pointed by ufcterm,
+**  and it is left unchanged.
+**
+**  NOTE: The function ignores coefficient of the UFCallTerm.
+**        So, -2*row(i)  is considered as just row(i)
+*/
 VarTerm* UFCallMap::find( UFCallTerm* ufc )
 {
-    UFCallTerm* ufcterm = ( (UFCallTerm*)(ufc->clone()) );
+    UFCallTerm* ufcterm = new UFCallTerm(*ufc);
     ufcterm->setCoefficient(1);
 
     std::map<UFCallTerm,VarTerm>::iterator it;
@@ -100,14 +111,21 @@ VarTerm* UFCallMap::find( UFCallTerm* ufc )
         return NULL;
     }
 
-    return ( (VarTerm*)(it->second).clone() );
+    VarTerm* result = new VarTerm(it->second);
+    return result;
 }
 
-//! Searches for a symbol in mVarParam2UFC. If it exists in the map, returns the
-//  equ. UFC, otherwise returns foo() (representing empty UFC)
+/*! Searches for a VarTerm in the map. If VarTerm exists in the map,
+**  it returns the pointer to equ. UFC, otherwise returns NULL. 
+**  The class does not own the object pointed by symbol,
+**  and it is left unchanged.
+**
+**  NOTE: The function ignores coefficient of the VarTerm.
+**        So, -2*row_i_  is considered as just row_i_
+*/
 UFCallTerm* UFCallMap::find( VarTerm* vt )
 {
-    VarTerm* sym = ( (VarTerm*)(vt->clone()) );
+    VarTerm* sym = new VarTerm(*vt);
     sym->setCoefficient(1);
     std::map<VarTerm,UFCallTerm>::iterator it;
 
@@ -117,7 +135,8 @@ UFCallTerm* UFCallMap::find( VarTerm* vt )
     }
     delete sym;
 
-    return ( (UFCallTerm*)(it->second).clone() );
+    UFCallTerm* result = new UFCallTerm(it->second) ;
+    return result;
 }
 
 // prints the content of the map into a string, and returns it

--- a/src/set_relation/UFCallMap.h
+++ b/src/set_relation/UFCallMap.h
@@ -26,16 +26,19 @@ class Set;
 
 /*!
  * \class UFCallMap
- * This class can store UFcalls and their equ. symbolic constants. 
+ * This class can store UFcalls and their equ. VarTerm. 
  * We need this in functionality of creating affine sets out of
  * non-affine sets, where UFcalls get replaced with symbolic constants.
+ * UFCallTerms and VarTerms are stored with coefficient = 1, however there is no
+ * need to set coefficient when inserting a UFCallTerm or searching for
+ * UFCallTerm or VarTerm in the map using find functions.
  */
 class UFCallMap {
 public:
     UFCallMap(){}
     ~UFCallMap(){
-               mUFC2Str.clear();
-               mStr2UFC.clear();
+               mUFC2VarParam.clear();
+               mVarParam2UFC.clear();
     }
 
     //! Copy constructor.
@@ -47,29 +50,36 @@ public:
     //! returns a string representing ufcterm as a symbolic constant
     string symUFC( std::string &ufcName );
 
-    //! Use this to insert a UFC term to maps.
-    //  The function creates an string representing the UFC then,
-    //  adds (ufc,str) to mUFC2Str & adds (ufc,str) to mStr2UFC
-    //  The class does not own the object pointed by *ufcterm,
-    //  so users are responsible for freeing the memory.
-    void insert( UFCallTerm *ufcterm );
+    /*! Use this to insert a UFCallTerm to map.
+    **  The function creates an VarTerm representing the UFC then,
+    **  adds (ufc,vt) to mUFC2VarParam & adds (vt,str) to mVarParam2UFC
+    **  The class does not own the object pointed by *ufcterm,
+    **  so users are responsible for freeing the memory.
+    **  There is no need to set coefficient of ufc, function insert a UFCallTerm
+    **  with coefficient = 1 to the map ithout changing ufc objevt.
+    */
+    void insert( UFCallTerm *ufc);
 
-    //! Searches for ufcterm in mUFC2Str. If it exists in the map, returns
-    // the equ. symbol, otherwise returns an empty string.
-    //  The class does not own the object pointed by *ufcterm,
-    //  so users are responsible for freeing the memory.
-    string find( UFCallTerm *ufcterm );
+    /*! Searches for ufcterm (with coefficient = 1) in the map. If ufcterm
+    **  exists, it returns a pointer to equ. VarTerm, otherwise returns NULL.
+    **  The class does not own the object pointed by ufcterm,
+    **  and it is left unchanged.
+    */
+    VarTerm* find( UFCallTerm* ufc );
 
-    //! Searches for a symbol in mStr2UFC. If it exists in the map, returns the
-    //  equ. UFC, otherwise returns foo() (representing empty UFC)
-    UFCallTerm find( string &symbol );
+    /*! Searches for a VarTerm (with coefficient = 1) in the map. If VarTerm
+    **  exists in the map, returns the pointer to equ. UFC,
+    **  otherwise returns NULL. The class does not own the object
+    **  pointed by symbol, and it is left unchanged.
+    */
+    UFCallTerm* find( VarTerm* symbol );
 
-    // prints the content of the map into a string, and returns it
+    //! prints the content of the map into a string, and returns it
     std::string toString();
 
 private:
-    std::map<UFCallTerm,string> mUFC2Str;
-    std::map<string,UFCallTerm> mStr2UFC;
+    std::map<UFCallTerm,VarTerm> mUFC2VarParam;
+    std::map<VarTerm,UFCallTerm> mVarParam2UFC;
 };
 
 }

--- a/src/set_relation/UFCallMap.h
+++ b/src/set_relation/UFCallMap.h
@@ -53,24 +53,31 @@ public:
     /*! Use this to insert a UFCallTerm to map.
     **  The function creates an VarTerm representing the UFC then,
     **  adds (ufc,vt) to mUFC2VarParam & adds (vt,str) to mVarParam2UFC
-    **  The class does not own the object pointed by *ufcterm,
-    **  so users are responsible for freeing the memory.
-    **  There is no need to set coefficient of ufc, function insert a UFCallTerm
-    **  with coefficient = 1 to the map ithout changing ufc objevt.
+    **  The class does not own the object pointed by ufcterm,
+    **  and it is left unchanged.
+    **
+    **  NOTE: The function ignores coefficient of the UFCallTerm.
+    **        So, -2*row(i)  is considered as just row(i)
     */
     void insert( UFCallTerm *ufc);
 
-    /*! Searches for ufcterm (with coefficient = 1) in the map. If ufcterm
-    **  exists, it returns a pointer to equ. VarTerm, otherwise returns NULL.
+    /*! Searches for ufcterm in the map. If ufcterm exists, it returns
+    **  a pointer to equ. VarTerm, otherwise returns NULL.
     **  The class does not own the object pointed by ufcterm,
     **  and it is left unchanged.
+    **
+    **  NOTE: The function ignores coefficient of the UFCallTerm.
+    **        So, -2*row(i)  is considered as just row(i)
     */
     VarTerm* find( UFCallTerm* ufc );
 
-    /*! Searches for a VarTerm (with coefficient = 1) in the map. If VarTerm
-    **  exists in the map, returns the pointer to equ. UFC,
-    **  otherwise returns NULL. The class does not own the object
-    **  pointed by symbol, and it is left unchanged.
+    /*! Searches for a VarTerm in the map. If VarTerm exists in the map,
+    **  it returns the pointer to equ. UFC, otherwise returns NULL. 
+    **  The class does not own the object pointed by symbol,
+    **  and it is left unchanged.
+    **
+    **  NOTE: The function ignores coefficient of the VarTerm.
+    **        So, -2*row_i_  is considered as just row_i_
     */
     UFCallTerm* find( VarTerm* symbol );
 

--- a/src/set_relation/UFCallMap_test.cc
+++ b/src/set_relation/UFCallMap_test.cc
@@ -55,17 +55,36 @@ TEST(UFCallMapTest, UFCallMap) {
 
 //////// Checking: UFC -> Symbolic Cnstant    ---LOOK UP
    ///   Finding a UFC in the map, and getting its "symbolic constant" form.
-    std::string symCons = map.find(ufcall);
+    VarTerm* symCons = map.find(ufcall);
 
-    EXPECT_EQ( "row___tv0P1__tv2Mn_" , symCons );
+    EXPECT_EQ( "row___tv0P1__tv2Mn_" , symCons->toString() );
 
 //////// Checking: Symbolic Constant -> UFC    ---LOOK UP
-   ///   Finding a "symbolic constant" in the map, and getting its equ. UFCall.
-    UFCallTerm r_ufcall("foo", 0);
-    r_ufcall = map.find(symCons);
+   ///   Finding a "symbolic constant" in the map, and getting its equ. UFC.
+    UFCallTerm* r_ufcall = map.find(symCons);
 
-    EXPECT_EQ( *ufcall , r_ufcall );
+    EXPECT_EQ( ufcall->toString() , r_ufcall->toString() );
+
+
+//////// Checking: The UFC is not in the map! So, we get NULL.
+    UFCallTerm *ufcallFoo = new UFCallTerm("Foo", 0);
+    
+    VarTerm* symConsFoo = map.find(ufcallFoo);
+    
+    if(symConsFoo){
+        delete symConsFoo;
+        symConsFoo = new VarTerm( 1,std::string("Found") );
+    }
+    else{
+        symConsFoo = new VarTerm( 1,std::string("notFound") );
+    }
+
+    EXPECT_EQ( "notFound" , symConsFoo->toString() ); 
 
 //    std::cout<<std::endl<<map.toString()<<std::endl;
     delete ufcall;
+    delete ufcallFoo;
+    delete r_ufcall;
+    delete symCons;
+    delete symConsFoo;
 }

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3607,7 +3607,17 @@ class VisitorSuperAffineSet : public Visitor {
          void preVisitTerm(Term * t) {
              if(visit){ affineExp->addTerm( t->clone() ); }
          }
-         void preVisitUFCallTerm(UFCallTerm * t);
+         //! We iterate over terms in Exp, if the term is not a UFCall
+         //  then we just add it to our affine set.
+         //  On the other hand, We need to turn UFCalls into
+         //  symbolic constants to make an affine set.
+         void preVisitUFCallTerm(UFCallTerm * t){
+             if(visit){
+                 VarTerm* vt = ufcmap->find( t );
+                 vt->setCoefficient(t->coefficient());
+                 affineExp->addTerm( vt );
+             }
+         }
          void preVisitTupleVarTerm(TupleVarTerm * t){
              if(visit){ affineExp->addTerm( t->clone() ); }
          }
@@ -3617,109 +3627,65 @@ class VisitorSuperAffineSet : public Visitor {
          void preVisitTupleExpTerm(TupleExpTerm * t){ 
              if(visit){ affineExp->addTerm( t->clone() ); }
          }
+         //! Intialize an affineExp if Exp is not a UFCall argument
+         // If this is a argument to a UFCall, we don't want to modify it.
+         // This is because A(B(i+1)) gets replaced with A_B_iP1__ without 
+         // doing anything about B(i+1). And keep in mind that we have already
+         // added constraints related to function B's domain and range.
+         void preVisitExp(iegenlib::Exp * e){
+             if( e->isExpression() ){
+                 visit = false;
+             }else{
+                 visit = true;
+                 affineExp = new Exp();  
+             }
+         }
+         void postVisitExp(iegenlib::Exp * e){
+             if( e->isExpression() ){
+                 visit = true;
+                 return;
+             }
+             Exp* CaffineExp = affineExp->clone();
+             if( e->isInequality() ){
+                 affineConj->addInequality( CaffineExp );
+             }else{
+                 affineConj->addEquality( CaffineExp );
+             }
+             delete affineExp;
+             visit = true;
+         }
+         //! Initializes an affineConj
+         void preVisitConjunction(iegenlib::Conjunction * c){
+             affineConj = new Conjunction( c->getTupleDecl() );
+             affineConj->setinarity( c->inarity() );
+         }
+         //! adds the current affineConj to maffineConj
+         void postVisitConjunction(iegenlib::Conjunction * c){
+             maffineConj.push_back(affineConj->clone());
+             delete affineConj;
+         }
+         //! Add Conjunctions in maffineConj to affineSet
+         void postVisitSet(iegenlib::Set * s){
+             affineSet = new Set( s->arity() );
 
-         void preVisitExp(iegenlib::Exp * e);
-         void postVisitExp(iegenlib::Exp * e);
-         void preVisitConjunction(iegenlib::Conjunction * c);
-         void postVisitConjunction(iegenlib::Conjunction * c);
-         void postVisitSet(iegenlib::Set * s);
-         void postVisitRelation(iegenlib::Relation * r);
+             for(std::list<Conjunction*>::const_iterator i=maffineConj.begin();
+                             i != maffineConj.end(); i++) {
+                 affineSet->addConjunction((*i));
+             }
+         }
+         //! Add Conjunctions in maffineConj to affineRelation
+         void postVisitRelation(iegenlib::Relation * r){
+             affineRelation = new Relation( r->inArity() , r->outArity() );
+
+             for(std::list<Conjunction*>::const_iterator i=maffineConj.begin();
+                              i != maffineConj.end(); i++) {
+                 affineRelation->addConjunction((*i));
+             }
+         }
+
          Set* getSet(){ return affineSet; }
          Relation* getRelation(){ return affineRelation; }
 };
-
-//! We iterate over terms in Exp, if the term is not a UFCall
-//  then we just add it to our affine set.
-//  On the other hand, We need to turn UFCalls into
-//  symbolic constants to make an affine set.
-void VisitorSuperAffineSet::preVisitUFCallTerm(UFCallTerm * t)
-{
-    if(!visit){
-        return;
-    }
-    UFCallTerm* cufc = (UFCallTerm*)(t->clone());
-    int cof = cufc->coefficient();
-    cufc->setCoefficient(1);
-    std::string SymConst = ufcmap->find( cufc ); 
-    VarTerm* vt = new VarTerm( cof , SymConst );
-    affineExp->addTerm( vt );
-    delete cufc;
-}
-
-//! Intialize an affineExp if Exp is not a UFCall argument
-void VisitorSuperAffineSet::preVisitExp(iegenlib::Exp * e)
-{
-    // If this is a argument to a UFCall, we don't want to modify it.
-    // This is because A(B(i+1)) gets replaced with A_B_iP1__ without 
-    // doing anything about B(i+1). And keep in mind that we have already
-    // added constraints related to function B's domain and range 
-    // (L < B(i+1) < U) with boundDomainRange functionality.
-    if( e->isExpression() )
-    {
-        visit = false;
-    }
-    else
-    {
-        visit = true;
-        affineExp = new Exp();  
-    }
-}
-void VisitorSuperAffineSet::postVisitExp(iegenlib::Exp * e)
-{
-    if( e->isExpression() )
-    {
-        visit = true;
-        return;
-    }
-
-    Exp* CaffineExp = affineExp->clone();
-    if( e->isInequality() )
-    {
-        affineConj->addInequality( CaffineExp );
-    }
-    else if( e->isEquality() )
-    {
-        affineConj->addEquality( CaffineExp );
-    }
-
-    delete affineExp;
-    visit = true;
-}
-
-//! Initializes an affineConj
-void VisitorSuperAffineSet::preVisitConjunction(iegenlib::Conjunction * c)
-{
-    affineConj = new Conjunction( c->getTupleDecl() );
-    affineConj->setinarity( c->inarity() );
-}
-
-//! adds the current affineConj to maffineConj
-void VisitorSuperAffineSet::postVisitConjunction(iegenlib::Conjunction * c)
-{
-    maffineConj.push_back(affineConj->clone());
-
-    delete affineConj;
-}
-//! Add Conjunctions in maffineConj to affineSet
-void VisitorSuperAffineSet::postVisitSet(iegenlib::Set * s)
-{
-    affineSet = new Set( s->arity() );
-
-    for (std::list<Conjunction*>::const_iterator i=maffineConj.begin();
-                i != maffineConj.end(); i++) {
-        affineSet->addConjunction((*i));
-    }
-}
-//! Add Conjunctions in maffineConj to affineRelation
-void VisitorSuperAffineSet::postVisitRelation(iegenlib::Relation * r)
-{
-    affineRelation = new Relation( r->inArity() , r->outArity() );
-
-    for (std::list<Conjunction*>::const_iterator i=maffineConj.begin();
-                i != maffineConj.end(); i++) {
-        affineRelation->addConjunction((*i));
-    }
-}
 
 //! Creates a super affine set from a non-affine set.
 //  To do this:
@@ -3761,16 +3727,15 @@ Relation* Relation::superAffineRelation(UFCallMap* ufcmap)
     return result;
 }
 
-
 /*****************************************************************************/
 #pragma mark -
-/*************** VisitorsubNonAffineSet *****************************/
+/*************** VisitorReverseAffineSubstitution *****************************/
 //! Vistor Class used in SuperAffineSet
 //  Used in traversing a Set/Relation to replace UFCs with symbolic constants
 //  We will build up a nonAffineSet (or nonAffineRelation), term by term.
 //  And if a term is UFCall, we will convert it to symbolic constant,
 //  which is pre-computed and stored in the ufcmap
-class VisitorsubNonAffineSet : public Visitor {
+class VisitorReverseAffineSubstitution : public Visitor {
   private:
          UFCallMap* ufcmap;
          Set* nonAffineSet;
@@ -3780,153 +3745,102 @@ class VisitorsubNonAffineSet : public Visitor {
          Exp* nonAffineExp;
          bool visit;       // helps to know which Exp is UFC argument
   public:
-         VisitorsubNonAffineSet(UFCallMap* imap){ufcmap = imap;}
-         // We do not change any type of Term except for VarTerm
+         VisitorReverseAffineSubstitution(UFCallMap* imap){ufcmap = imap;}
+
+         //! We iterate over terms in Exp, if the term is not a VarTerm
+         //  then we just add it to our non-affine set. On the other hand,
+         //  if a symbolic constants is in our ufcmap, we need to turn it
+         //  into corresponding UFCalls to make an non-affine set.
          void preVisitTerm(Term * t) {
              if(visit){ nonAffineExp->addTerm( t->clone() ); }
          }
-         void preVisitUFCallTerm(UFCallTerm * t);
+         //! Affine seta cannot have UFC terms!
+         void preVisitUFCallTerm(UFCallTerm * t){
+             throw assert_exception("VisitorReverseAffineSubstitution: \
+                             An UFCall term found in affine set!");
+         } 
          void preVisitTupleVarTerm(TupleVarTerm * t){
              if(visit){ nonAffineExp->addTerm( t->clone() ); }
          }
-         void preVisitVarTerm(VarTerm * t);
+         void preVisitVarTerm(VarTerm * t){
+             if(visit){
+                 UFCallTerm* ufc = (UFCallTerm*)(ufcmap->find( t ));
+                 if(!ufc){
+                     nonAffineExp->addTerm( t->clone() );
+                 } else {
+                     ufc->setCoefficient(t->coefficient());
+                     nonAffineExp->addTerm( ufc );
+                 }
+             }
+         }
          void preVisitTupleExpTerm(TupleExpTerm * t){ 
              if(visit){ nonAffineExp->addTerm( t->clone() ); }
          }
+         //! Intialize an nonAffineExp if Exp is not a UFCall argument
+         //  See VisitorsuperAffineSet::preVisitExp for more details
+         void preVisitExp(iegenlib::Exp * e){
+             if( e->isExpression() ){
+                 visit = false;
+             } else {
+                 visit = true;
+                 nonAffineExp = new Exp();  
+             }
+         }
+         void postVisitExp(iegenlib::Exp * e){
+             if( e->isExpression() ){
+                 visit = true;
+                 return;
+             }
+             Exp* CaffineExp = nonAffineExp->clone();
+             if( e->isInequality() ){
+                 nonAffineConj->addInequality( CaffineExp );
+             } else {
+                 nonAffineConj->addEquality( CaffineExp );
+             }
+             delete nonAffineExp;
+             visit = true;
+         }
+         //! Initializes an nonAffineConj
+         void preVisitConjunction(iegenlib::Conjunction * c){
+             nonAffineConj = new Conjunction( c->getTupleDecl() );
+             nonAffineConj->setinarity( c->inarity() );
+         }
+         //! adds the current nonAffineConj to nonMAffineConj
+         void postVisitConjunction(iegenlib::Conjunction * c){
+             nonMAffineConj.push_back(nonAffineConj->clone());
+             delete nonAffineConj;
+         }
+         //! Add Conjunctions in nonMAffineConj to nonAffineSet
+         void postVisitSet(iegenlib::Set * s){
+             nonAffineSet = new Set( s->arity() );
 
-         void preVisitExp(iegenlib::Exp * e);
-         void postVisitExp(iegenlib::Exp * e);
-         void preVisitConjunction(iegenlib::Conjunction * c);
-         void postVisitConjunction(iegenlib::Conjunction * c);
-         void postVisitSet(iegenlib::Set * s);
-         void postVisitRelation(iegenlib::Relation * r);
+             for (std::list<Conjunction*>::const_iterator i =
+                  nonMAffineConj.begin(); i != nonMAffineConj.end(); i++){
+                 nonAffineSet->addConjunction((*i));
+             }
+         }
+         //! Add Conjunctions in nonMAffineConj to nonAffineRelation
+         void postVisitRelation(iegenlib::Relation * r){
+             nonAffineRelation = new Relation( r->inArity() , r->outArity() );
+             for (std::list<Conjunction*>::const_iterator i =
+                  nonMAffineConj.begin(); i != nonMAffineConj.end(); i++){
+                 nonAffineRelation->addConjunction((*i));
+             }
+         }
          Set* getSet(){ return nonAffineSet; }
          Relation* getRelation(){ return nonAffineRelation; }
 };
-
-//! We iterate over terms in Exp, if the term is not a VarTerm
-//  then we just add it to our non-affine set.
-//  On the other hand, if a symbolic constants is in our ufcmap,
-//  we need to turn it into corresponding UFCalls to make an non-affine set.
-void VisitorsubNonAffineSet::preVisitVarTerm(VarTerm * t)
-{
-    if(!visit){
-        return;
-    }
-
-    VarTerm* cvt = (VarTerm*)(t->clone());
-    int cof = cvt->coefficient();
-    cvt->setCoefficient(1);
-    std::string symCons = cvt->symbol();
-    UFCallTerm* ufc = new UFCallTerm ( ufcmap->find( symCons ) );
-    UFCallTerm foo("foo", 0);
-
-    if( *ufc == foo )
-    {
-        nonAffineExp->addTerm( t->clone() );
-    }
-    else
-    {
-        ufc->setCoefficient(cof);
-        nonAffineExp->addTerm( ufc );
-    }
-    delete cvt;
-}
-
-void VisitorsubNonAffineSet::preVisitUFCallTerm(UFCallTerm * t)
-{
-  try
-  {
-    throw 1;
-  }
-  catch (int e)
-  {
-    std::cout<<std::endl<<
-               "VisitorsubNonAffineSet: An UFCall term found in affine set!"
-             <<std::endl;
-  }
-}
-
-//! Intialize an nonAffineExp if Exp is not a UFCall argument
-void VisitorsubNonAffineSet::preVisitExp(iegenlib::Exp * e)
-{
-    // If this is a argument to a UFCall, we don't want to modify it.
-    if( e->isExpression() )
-    {
-        visit = false;
-    }
-    else
-    {
-        visit = true;
-        nonAffineExp = new Exp();  
-    }
-}
-void VisitorsubNonAffineSet::postVisitExp(iegenlib::Exp * e)
-{
-    if( e->isExpression() )
-    {
-        visit = true;
-        return;
-    }
-
-    Exp* CaffineExp = nonAffineExp->clone();
-    if( e->isInequality() )
-    {
-        nonAffineConj->addInequality( CaffineExp );
-    }
-    else if( e->isEquality() )
-    {
-        nonAffineConj->addEquality( CaffineExp );
-    }
-
-    delete nonAffineExp;
-    visit = true;
-}
-
-//! Initializes an nonAffineConj
-void VisitorsubNonAffineSet::preVisitConjunction(iegenlib::Conjunction * c)
-{
-    nonAffineConj = new Conjunction( c->getTupleDecl() );
-    nonAffineConj->setinarity( c->inarity() );
-}
-
-//! adds the current nonAffineConj to nonMAffineConj
-void VisitorsubNonAffineSet::postVisitConjunction(iegenlib::Conjunction * c)
-{
-    nonMAffineConj.push_back(nonAffineConj->clone());
-
-    delete nonAffineConj;
-}
-//! Add Conjunctions in nonMAffineConj to nonAffineSet
-void VisitorsubNonAffineSet::postVisitSet(iegenlib::Set * s)
-{
-    nonAffineSet = new Set( s->arity() );
-
-    for (std::list<Conjunction*>::const_iterator i=nonMAffineConj.begin();
-                i != nonMAffineConj.end(); i++) {
-        nonAffineSet->addConjunction((*i));
-    }
-}
-//! Add Conjunctions in nonMAffineConj to nonAffineRelation
-void VisitorsubNonAffineSet::postVisitRelation(iegenlib::Relation * r)
-{
-    nonAffineRelation = new Relation( r->inArity() , r->outArity() );
-
-    for (std::list<Conjunction*>::const_iterator i=nonMAffineConj.begin();
-                i != nonMAffineConj.end(); i++) {
-        nonAffineRelation->addConjunction((*i));
-    }
-}
 
 //! Creates a super affine set from a non-affine set.
 //  To do this:
 //    (1) We add constraints due to all UFCalls' domain and range
 //    (2) We replace all UFCalls with symbolic constants found in the ufc map.
 //  The function does not own the ufcmap.
-Set* Set::subNonAffineSet(UFCallMap* ufcmap)
+Set* Set::reverseAffineSubstitution(UFCallMap* ufcmap)
 {
     Set* copySet = new Set( this->toISLString() );
-    VisitorsubNonAffineSet* v = new VisitorsubNonAffineSet(ufcmap);
+    VisitorReverseAffineSubstitution* v = 
+                  new VisitorReverseAffineSubstitution(ufcmap);
     
     copySet = copySet->boundDomainRange();
 
@@ -3941,10 +3855,10 @@ Set* Set::subNonAffineSet(UFCallMap* ufcmap)
 }
 
 //! Same as Set
-Relation* Relation::subNonAffineRelation(UFCallMap* ufcmap)
+Relation* Relation::reverseAffineSubstitution(UFCallMap* ufcmap)
 {
     Relation* copyRelation = new Relation( inArity(), outArity());
-    VisitorsubNonAffineSet* v = new VisitorsubNonAffineSet(ufcmap);
+    VisitorReverseAffineSubstitution* v = new VisitorReverseAffineSubstitution(ufcmap);
     
     copyRelation = this->boundDomainRange();
 

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3807,7 +3807,7 @@ class VisitorsubNonAffineSet : public Visitor {
 //! We iterate over terms in Exp, if the term is not a VarTerm
 //  then we just add it to our non-affine set.
 //  On the other hand, if a symbolic constants is in our ufcmap,
-//  we need to turn it into coresponding UFCalls to make an non-affine set.
+//  we need to turn it into corresponding UFCalls to make an non-affine set.
 void VisitorsubNonAffineSet::preVisitVarTerm(VarTerm * t)
 {
     if(!visit){

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -544,6 +544,12 @@ public:
     //  The function does not own the ufcmap.
     Set* superAffineSet(UFCallMap* ufcmap);
 
+    //! Creates a sun non-affine set from a affine set.
+    //  By replacing symbolic constants that are representitive of UFCalls
+    //  with their respective UFCalls.
+    //  The function does not own the ufcmap.
+    Set* subNonAffineSet(UFCallMap* ufcmap);
+
     //  Projects out tuple varrable No. tvar
     Set* projectOut(int tvar);
 
@@ -694,6 +700,12 @@ public:
     //    (2) We replace all UFCalls with symbolic constants found in the ufc map.
     //  The function does not own the ufcmap.
     Relation* superAffineRelation(UFCallMap* ufcmap);
+
+    //! Creates a sun non-affine set from a affine Relation.
+    //  By replacing symbolic constants that are representitive of UFCalls
+    //  with their respective UFCalls.
+    //  The function does not own the ufcmap.
+    Relation* subNonAffineRelation(UFCallMap* ufcmap);
 
     // Projects out tuple varrable No. tvar
     Relation* projectOut(int tvar);

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -533,22 +533,24 @@ public:
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);    
 
-    //! Adds constraints due to domain and range of all UFCalls in UFCallmap
-    //  Users own the returned Set object.
+    /*! Adds constraints due to domain and range of all UFCalls in UFCallmap
+    **  Users own the returned Set object.
+    */
     Set* boundDomainRange();
 
-    //! Creates a super affine set from a non-affine set.
-    //  To do this:
-    //    (1) We add constraints due to all UFCalls' domain and range
-    //    (2) We replace all UFCalls with symbolic constants found in the ufc map.
-    //  The function does not own the ufcmap.
+    /*! Creates a super affine set from a non-affine set.
+    **  To do this:
+    **    (1) We add constraints due to all UFCalls' domain and range
+    **    (2) We replace all UFCalls with symbolic constants found in the ufc map.
+    **  The function does not own the ufcmap.
+    */
     Set* superAffineSet(UFCallMap* ufcmap);
 
-    //! Creates a sub non-affine set from an affine set.
-    //  By replacing symbolic constants that are representative of UFCalls
-    //  with their respective UFCalls.
-    //  The function does not own the ufcmap.
-    Set* subNonAffineSet(UFCallMap* ufcmap);
+    /*! Creates a sub non-affine set from an affine set.
+    **  By replacing symbolic constants that are representative of UFCalls
+    **  with their respective UFCalls. The function does not own the ufcmap.
+    */
+    Set* reverseAffineSubstitution(UFCallMap* ufcmap);
 
     //  Projects out tuple varrable No. tvar
     Set* projectOut(int tvar);
@@ -690,22 +692,25 @@ public:
     //! Visitor design pattern, see Visitor.h for usage
     void acceptVisitor(Visitor *v);
 
-    //! Adds constraints due to domain and range of all UFCalls in UFCallmap
-    //  Users own the returned Relation object.
+    /*! Adds constraints due to domain and range of all UFCalls in UFCallmap
+    **  Users own the returned Relation object.
+    */
     Relation* boundDomainRange();
 
-    //! Creates a super affine Relation from a non-affine Relation.
-    //  To do this:
-    //    (1) We add constraints due to all UFCalls' domain and range
-    //    (2) We replace all UFCalls with symbolic constants found in the ufc map.
-    //  The function does not own the ufcmap.
+    /*! Creates a super affine Relation from a non-affine Relation.
+    **  To do this:
+    **    (1) We add constraints due to all UFCalls' domain and range
+    **    (2) We replace all UFCalls with symbolic constants found in the ufc map.
+    **  The function does not own the ufcmap.
+    */
     Relation* superAffineRelation(UFCallMap* ufcmap);
 
-    //! Creates a sub non-affine set from an affine Relation.
-    //  By replacing symbolic constants that are representative of UFCalls
-    //  with their respective UFCalls.
-    //  The function does not own the ufcmap.
-    Relation* subNonAffineRelation(UFCallMap* ufcmap);
+    /*! Creates a sub non-affine set from an affine Relation.
+    **  By replacing symbolic constants that are representative of UFCalls
+    **  with their respective UFCalls.
+    **  The function does not own the ufcmap.
+    */
+    Relation* reverseAffineSubstitution(UFCallMap* ufcmap);
 
     // Projects out tuple varrable No. tvar
     Relation* projectOut(int tvar);

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -544,8 +544,8 @@ public:
     //  The function does not own the ufcmap.
     Set* superAffineSet(UFCallMap* ufcmap);
 
-    //! Creates a sun non-affine set from a affine set.
-    //  By replacing symbolic constants that are representitive of UFCalls
+    //! Creates a sub non-affine set from an affine set.
+    //  By replacing symbolic constants that are representative of UFCalls
     //  with their respective UFCalls.
     //  The function does not own the ufcmap.
     Set* subNonAffineSet(UFCallMap* ufcmap);
@@ -701,8 +701,8 @@ public:
     //  The function does not own the ufcmap.
     Relation* superAffineRelation(UFCallMap* ufcmap);
 
-    //! Creates a sun non-affine set from a affine Relation.
-    //  By replacing symbolic constants that are representitive of UFCalls
+    //! Creates a sub non-affine set from an affine Relation.
+    //  By replacing symbolic constants that are representative of UFCalls
     //  with their respective UFCalls.
     //  The function does not own the ufcmap.
     Relation* subNonAffineRelation(UFCallMap* ufcmap);

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3930,3 +3930,86 @@ TEST_F(SetRelationTest, superAffineSet) {
     delete su_r1;
 
 }
+
+#pragma mark subNonAffineSet
+//Testing subNonAffineSet/Relation: creating sub non-affine Sets
+TEST_F(SetRelationTest, subNonAffineRelation) {
+
+    iegenlib::setCurrEnv();
+    iegenlib::appendCurrEnv("col",
+        new Set("{[i,t]:0<=i && i< m && 0<=t && t< m}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+    iegenlib::appendCurrEnv("idx",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<m}"), true, iegenlib::Monotonic_NONE);
+
+    iegenlib::UFCallMap *ufcmap;
+
+    //!  ----------------   Testing subNonAffineSet     ------------
+
+    Set *s1 = new Set("[n] -> { [i,j] : idx(col(i,j)) < n}");
+
+    Set *ex_s1 = new Set ("{ [i, j] : i >= 0 && j >= 0 && col(i,j) >= 0 &&"
+          " idx(col(i, j)) >= 0 && i < m && j < m && idx(col(i, j)) < m &&"
+                                     " col(i, j) < n && idx(col(i,j))< n }");
+
+    //! Geting a map of UFCalls  ---------------
+    ufcmap = s1->mapUFCtoSym();
+    //! Getting the superAffineSet
+    Set* su_s1 = s1->superAffineSet(ufcmap);
+
+    //! Getting the subNonAffineSet
+    Set* sub_s1 = su_s1->subNonAffineSet(ufcmap);
+//    std::cout<<std::endl<<sub_s1->toString()<<std::endl;
+
+    EXPECT_EQ( ex_s1->toString() , sub_s1->toString() );
+
+    delete ufcmap;
+
+    Set* s2 = new Set( "{[i]: 0<=idx(i)[0] && idx(i)[1]<Nv}");
+
+    Set *ex_s2 = new Set ("{ [i] : i >= 0 && idx(i)[0] >= 0 && idx(i)[1] >= 0"
+            " && i < n && idx(i)[1] < Nv && idx(i)[0] < m && idx(i)[1] < m}");
+
+    //! Geting a map of UFCalls  ---------------
+    ufcmap = s2->mapUFCtoSym();
+    //! Getting the superAffineSet
+    Set* su_s2 = s2->superAffineSet(ufcmap);
+
+     //! Getting the subNonAffineSet
+    Set* sub_s2 = su_s2->subNonAffineSet(ufcmap);
+//    std::cout<<std::endl<<sub_s2->toString()<<std::endl;
+
+    EXPECT_EQ( ex_s2->toString() , sub_s2->toString() );
+
+    delete ufcmap;
+
+    //!  ----------------   Testing subNonAffineRelation  ---------
+
+    Relation* r1 = new Relation("[n] -> { [i,j] -> [ip,jp] :"
+       " i = col(jp,idx(j)) and i < ip and ip < n }");
+
+    Relation* ex_r1 = new Relation("{ [i, j] -> [ip, jp] : i = col(jp, idx(j))"
+      " && j >= 0 && jp >= 0 && col(jp, idx(j)) >= 0 && idx(j) >= 0 && i < ip"
+       " && j < n && ip < n && jp < m && idx(j)< m && col(jp, idx(j)) < n }");
+
+    //! Geting a map of UFCalls  ---------------
+    ufcmap = r1->mapUFCtoSym();
+    Relation* su_r1 = r1->superAffineRelation(ufcmap);
+
+    //! Getting the subNonAffineSet
+    Relation* sub_r1 = su_r1->subNonAffineRelation(ufcmap);
+//    std::cout<<std::endl<<sub_r1->toString()<<std::endl;
+
+    EXPECT_EQ( ex_r1->toString() , sub_r1->toString() );
+
+    delete ufcmap;
+
+    delete s1;
+    delete su_s1;
+    delete s2;
+    delete su_s2;
+    delete r1;
+    delete su_r1;
+
+}

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3958,7 +3958,7 @@ TEST_F(SetRelationTest, reverseAffineSubstitution) {
     //! Getting the superAffineSet
     Set* su_s1 = s1->superAffineSet(ufcmap);
 
-    //! Getting the subNonAffineSet
+    //! Getting the reverseAffineSubstitution
     Set* sub_s1 = su_s1->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_s1->toString()<<std::endl;
 
@@ -3976,7 +3976,7 @@ TEST_F(SetRelationTest, reverseAffineSubstitution) {
     //! Getting the superAffineSet
     Set* su_s2 = s2->superAffineSet(ufcmap);
 
-     //! Getting the subNonAffineSet
+     //! Getting the reverseAffineSubstitution
     Set* sub_s2 = su_s2->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_s2->toString()<<std::endl;
 
@@ -3997,7 +3997,7 @@ TEST_F(SetRelationTest, reverseAffineSubstitution) {
     ufcmap = r1->mapUFCtoSym();
     Relation* su_r1 = r1->superAffineRelation(ufcmap);
 
-    //! Getting the subNonAffineSet
+    //! Getting the reverseAffineSubstitution
     Relation* sub_r1 = su_r1->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_r1->toString()<<std::endl;
 

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3931,9 +3931,9 @@ TEST_F(SetRelationTest, superAffineSet) {
 
 }
 
-#pragma mark subNonAffineSet
-//Testing subNonAffineSet/Relation: creating sub non-affine Sets
-TEST_F(SetRelationTest, subNonAffineRelation) {
+#pragma mark reverseAffineSubstitution
+//Testing reverseAffineSubstitution: creating sub non-affine Sets
+TEST_F(SetRelationTest, reverseAffineSubstitution) {
 
     iegenlib::setCurrEnv();
     iegenlib::appendCurrEnv("col",
@@ -3945,7 +3945,7 @@ TEST_F(SetRelationTest, subNonAffineRelation) {
 
     iegenlib::UFCallMap *ufcmap;
 
-    //!  ----------------   Testing subNonAffineSet     ------------
+    //! --------   Testing reverseAffineSubstitution for Set ---
 
     Set *s1 = new Set("[n] -> { [i,j] : idx(col(i,j)) < n}");
 
@@ -3959,7 +3959,7 @@ TEST_F(SetRelationTest, subNonAffineRelation) {
     Set* su_s1 = s1->superAffineSet(ufcmap);
 
     //! Getting the subNonAffineSet
-    Set* sub_s1 = su_s1->subNonAffineSet(ufcmap);
+    Set* sub_s1 = su_s1->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_s1->toString()<<std::endl;
 
     EXPECT_EQ( ex_s1->toString() , sub_s1->toString() );
@@ -3977,14 +3977,14 @@ TEST_F(SetRelationTest, subNonAffineRelation) {
     Set* su_s2 = s2->superAffineSet(ufcmap);
 
      //! Getting the subNonAffineSet
-    Set* sub_s2 = su_s2->subNonAffineSet(ufcmap);
+    Set* sub_s2 = su_s2->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_s2->toString()<<std::endl;
 
     EXPECT_EQ( ex_s2->toString() , sub_s2->toString() );
 
     delete ufcmap;
 
-    //!  ----------------   Testing subNonAffineRelation  ---------
+    //! --------   Testing reverseAffineSubstitution  for Relation ---
 
     Relation* r1 = new Relation("[n] -> { [i,j] -> [ip,jp] :"
        " i = col(jp,idx(j)) and i < ip and ip < n }");
@@ -3998,7 +3998,7 @@ TEST_F(SetRelationTest, subNonAffineRelation) {
     Relation* su_r1 = r1->superAffineRelation(ufcmap);
 
     //! Getting the subNonAffineSet
-    Relation* sub_r1 = su_r1->subNonAffineRelation(ufcmap);
+    Relation* sub_r1 = su_r1->reverseAffineSubstitution(ufcmap);
 //    std::cout<<std::endl<<sub_r1->toString()<<std::endl;
 
     EXPECT_EQ( ex_r1->toString() , sub_r1->toString() );


### PR DESCRIPTION
For reverseAffineSubstitution, we iterate over terms in Exp, if the term is not a VarTerm then we just add it to our non-affine set. On the other hand, if a symbolic constants is in our ufcmap,  we need to turn it into corresponding UFCalls to make an non-affine set.

I updated UFCallMap behavior. It stores UFCallTerms to VarTerms now, and it handles coefficient of UFCallTerms and VarTerms itself. This means users just insert UFC without setting its coefficient, and the object is left unchanged. Also, users can find for UFCalls or VarTerms without worrying about coefficient.
