### PR TITLE
Add constraints due to monotonicity

### DIFF
--- a/src/set_relation/TermPartOrdGraph.cc
+++ b/src/set_relation/TermPartOrdGraph.cc
@@ -248,21 +248,21 @@ void termMapCopyTerms( const std::map<TermType,int>& termMap,
 
 //! Returns a set of all unique UFCallTerms that have been inserted.
 //! Caller owns all of the return Terms.
-std::set<UFCallTerm*> TermPartOrdGraph::getUniqueUFCallTerms() const {
-    std::set<UFCallTerm*> uniqueUFCallTerms;
+std::set<UFCallTerm*> TermPartOrdGraph::getUniqueUFCallTerms() {
+    mUniqueUFCallTerms.clear();
     termMapCopyTerms<UFCallTerm*,UFCallTerm>(mUFCallTerm2IntMap,
-                                             uniqueUFCallTerms);
-    return uniqueUFCallTerms;
+                                             mUniqueUFCallTerms);
+    return mUniqueUFCallTerms;
 }
 
 //! Returns a set of all unique terms that have been inserted.
-std::set<Term*> TermPartOrdGraph::getAllUniqueTerms() const {
+/*std::set<Term*> TermPartOrdGraph::getAllUniqueTerms() const {
     std::set<Term*> uniqueTerms;
     termMapCopyTerms<Term*,UFCallTerm>(mUFCallTerm2IntMap, uniqueTerms);
     termMapCopyTerms<Term*,TupleVarTerm>(mTupleVarTerm2IntMap, uniqueTerms);
     termMapCopyTerms<Term*,VarTerm>(mVarTerm2IntMap, uniqueTerms);
     return uniqueTerms;
-}
+}*/
 
 //! Templated helper routine to avoid repetitive code that
 //! loops over the type specific term maps to generate a

--- a/src/set_relation/TermPartOrdGraph.cc
+++ b/src/set_relation/TermPartOrdGraph.cc
@@ -139,7 +139,7 @@ bool TermPartOrdGraph::isNonNegative( const Term* term ) const {
     Term* temp = term->clone();
     temp->setCoefficient(1);
     bool retval = false;
-std::cout << "TermPartOrdGraph::isNonNegative: temp = " << temp->toString() << std::endl;
+
     // Search through the Set of non-negative terms and see
     // if it is in there.
     std::set<Term*>::const_iterator iter;

--- a/src/set_relation/TermPartOrdGraph.h
+++ b/src/set_relation/TermPartOrdGraph.h
@@ -125,12 +125,15 @@ public:
     bool isEqual( Term* term1, Term* term2 );
 
     //! Returns a set of all unique UFCallTerms that have been inserted.
-    //! Caller will own returned terms.
-    std::set<UFCallTerm*> getUniqueUFCallTerms() const;
+    //! Caller does NOT own returned terms.
+    std::set<UFCallTerm*> getUniqueUFCallTerms();
 
     //! Returns a set of all unique terms that have been inserted.
-    //! Caller will own returned terms.
-    std::set<Term*> getAllUniqueTerms() const;
+    //! Caller will own returned terms.  FIXME: can we return owned ptrs or something?
+//    std::set<Term*> getAllUniqueTerms() const;
+// Don't think we need this and having it causes a cleanup pain.  Although
+// just realized I could keep a set of the copies in here and then clean them up
+// upon destruction.
     
     //! Returns a string representation of the class instance for debugging.
     std::string toString() const;        
@@ -143,6 +146,9 @@ private:
     std::map<VarTerm,int>       mVarTerm2IntMap;
     
     std::set<Term*>             mNonNegativeTerms;
+    
+    // kept so can own and clean up
+    std::set<UFCallTerm*>       mUniqueUFCallTerms; 
     
     PartOrdGraph*               mGraphPtr;
     

--- a/src/set_relation/TermPartOrdGraph_test.cc
+++ b/src/set_relation/TermPartOrdGraph_test.cc
@@ -243,8 +243,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphPartOrd) {
     g.insertLTE(uf_call1,uf_call2);
     g.insertLT(uf_call3,uf_call1);
     
-    std::cout << g.toString();
-
     EXPECT_EQ(true, g.isLT(v,uf_call2));
     EXPECT_EQ(false, g.isLT(uf_call2,v));
     EXPECT_EQ(true, g.isLT(uf_call3,uf_call2));

--- a/src/set_relation/TermPartOrdGraph_test.cc
+++ b/src/set_relation/TermPartOrdGraph_test.cc
@@ -108,8 +108,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphUniqueTerms) {
     // Check the size of the unique sets.
     std::set<UFCallTerm*> ufCallTermSet = g.getUniqueUFCallTerms();
     EXPECT_EQ(0,ufCallTermSet.size());
-    std::set<Term*> termSet = g.getAllUniqueTerms();
-    EXPECT_EQ(1,termSet.size());
     }
     
     // term = tau(i,j)
@@ -128,8 +126,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphUniqueTerms) {
     // Check the size of the unique sets.
     std::set<UFCallTerm*> ufCallTermSet = g.getUniqueUFCallTerms();
     EXPECT_EQ(1,ufCallTermSet.size());
-    std::set<Term*> termSet = g.getAllUniqueTerms();
-    EXPECT_EQ(2,termSet.size());
     }
         
     // Inserting same thing twice on purpose.
@@ -149,8 +145,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphUniqueTerms) {
     // Check the size of the unique sets.
     std::set<UFCallTerm*> ufCallTermSet = g.getUniqueUFCallTerms();
     EXPECT_EQ(1,ufCallTermSet.size());
-    std::set<Term*> termSet = g.getAllUniqueTerms();
-    EXPECT_EQ(2,termSet.size());
     }
 
     // term = g(3 __tv3)
@@ -166,8 +160,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphUniqueTerms) {
     // Check the size of the unique sets.
     std::set<UFCallTerm*> ufCallTermSet = g.getUniqueUFCallTerms();
     EXPECT_EQ(2,ufCallTermSet.size());
-    std::set<Term*> termSet = g.getAllUniqueTerms();
-    EXPECT_EQ(3,termSet.size());
     }
 
     // term = g(2 __tv3)
@@ -183,8 +175,6 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphUniqueTerms) {
     // Check the size of the unique sets.
     std::set<UFCallTerm*> ufCallTermSet = g.getUniqueUFCallTerms();
     EXPECT_EQ(3,ufCallTermSet.size());
-    std::set<Term*> termSet = g.getAllUniqueTerms();
-    EXPECT_EQ(4,termSet.size());
     }
 
     // Have to clean up all terms that were put into part ord,

--- a/src/set_relation/UninterpFunc.h
+++ b/src/set_relation/UninterpFunc.h
@@ -35,7 +35,8 @@ class Set;
  */
 typedef enum {
     Monotonic_NONE,
-    Monotonic_Nondecreasing
+    Monotonic_Nondecreasing,
+    Monotonic_Increasing
     // Here is where others would go when we get them
 } MonotonicType;
 

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3119,13 +3119,10 @@ Set* Set::addConstraintsDueToMonotonicity() const {
     // Add in constraints due to domain and range.
     // We always want to do this hear because otherwise we don't get
     // any of the uninterpreted functions as non-negative.
-    Set* retval = new Set(*this);
+    Set* retval = this->boundDomainRange();
     
-    // FIXME: not happy about how this works now.  Mahdi is fixing.
-//    UFCallMapAndBounds ufcallmap(getTupleDecl());
-//    retval->ufCallsToTempVars(ufcallmap);
-//std::cout << "After ufCallsToTempVars, retval = " << retval->toString() << std::endl;
-    
+    // FIXME: inconsistency as to whether these methods update current
+    // or return a new.    
     retval->addConstraintsDueToMonotonicityHelper();
     return retval;
 }
@@ -3551,7 +3548,7 @@ void VisitorBoundDomainRange::postVisitConjunction(Conjunction * c)
 
 //! Adds constraints due to domain and range of all UFCalls in UFCallmap
 //  Users own the returned Set object.
-Set* Set::boundDomainRange()
+Set* Set::boundDomainRange() const
 {
     Set* s = new Set(*this);
     VisitorBoundDomainRange *v = new VisitorBoundDomainRange();
@@ -3565,7 +3562,7 @@ Set* Set::boundDomainRange()
 
 //! Adds constraints due to domain and range of all UFCalls in UFCallmap
 //  Users own the returned Relation object.
-Relation* Relation::boundDomainRange()
+Relation* Relation::boundDomainRange() const
 {
     Relation* r = new Relation(*this);
     VisitorBoundDomainRange *v = new VisitorBoundDomainRange();

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3018,8 +3018,6 @@ class VisitorCollectPartOrd : public Visitor {
             
         } // endif e->isInequality()
 
-std::cout << "mPartOrd = " << mPartOrd.toString() << std::endl;
-
     }
 
     void postVisitTerm(iegenlib::Term * t) {
@@ -3068,8 +3066,6 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
             conjunct->acceptVisitor(&v2);
         } while (!(v2.hasConverged()));
         partOrd = v2.returnPartOrd();
-std::cout << "partOrd = " << partOrd.toString() << std::endl;
-    
 
         // For each UFCall term that involves monotonically non-decreasing
         // function, put in new constraints that can be derived based on
@@ -3097,19 +3093,16 @@ std::cout << "partOrd = " << partOrd.toString() << std::endl;
                     new_constraint->addExp(smallerExp);
                     new_constraint->addExp(ufCall2->getParamExp(0)->clone());
 
-std::cout << "partOrd.isLT(ufCall1,ufCall2) = " << partOrd.isLT(ufCall1,ufCall2) << std::endl;
                     // if ufCall1(e1) < ufCall2(e2) then e1 < e2
                     if (partOrd.isLT(ufCall1,ufCall2)) {
                         // largerTerm - smallerTerm - 1 >= 0
                         new_constraint->addTerm(new Term(-1));
                         conjunct->addInequality(new_constraint);
-std::cout << "new_constraint being added = " << new_constraint->toString() << std:: endl;
                         
                     // if ufCall1(e1) <= ufCall2(e2) then e1 <= e2
                     } else if (partOrd.isLTE(ufCall1,ufCall2)) {
                         // largerTerm - smallerTerm >= 0
                         conjunct->addInequality(new_constraint);
-std::cout << "new_constraint being added = " << new_constraint->toString() << std:: endl;
                         
                     } else {
                         delete new_constraint;
@@ -3122,9 +3115,12 @@ std::cout << "new_constraint being added = " << new_constraint->toString() << st
 
 
 Set* Set::addConstraintsDueToMonotonicity() const {
-    Set* retval = new Set(*this);
     
     // Add in constraints due to domain and range.
+    // We always want to do this hear because otherwise we don't get
+    // any of the uninterpreted functions as non-negative.
+    Set* retval = new Set(*this);
+    
     // FIXME: not happy about how this works now.  Mahdi is fixing.
 //    UFCallMapAndBounds ufcallmap(getTupleDecl());
 //    retval->ufCallsToTempVars(ufcallmap);

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -2699,9 +2699,11 @@ void SparseConstraints::addUFConstraintsHelper(std::string uf1str,
     VisitorFindUFCallTerms * v1 = new VisitorFindUFCallTerms(uf1str);
     this->acceptVisitor(v1);
     std::set<UFCallTerm> uf1Terms = v1->returnResult();
+    delete v1;
     VisitorFindUFCallTerms * v2 = new VisitorFindUFCallTerms(uf2str);
     this->acceptVisitor(v2);
     std::set<UFCallTerm> uf2Terms = v2->returnResult();
+    delete v2;
     
     // Rename all of the uf2Terms functions to uf1 and
     // insert into uf1Terms set so don't get repetition of same
@@ -3081,8 +3083,10 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
                 if (ufCall1->name()==ufCall2->name()
                         && ufCall1->numArgs()==1
                         && ufCall2->numArgs()==1
-                        && Monotonic_Nondecreasing
-                           ==queryMonoTypeEnv(ufCall1->name()) ) {
+                        && ((Monotonic_Nondecreasing
+                             ==queryMonoTypeEnv(ufCall1->name()))
+                            || (Monotonic_Increasing
+                             ==queryMonoTypeEnv(ufCall1->name())) ) ) {
                 
                     // if ufCall1(e1) == ufCall2(e2) then useful??
 
@@ -3110,7 +3114,14 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
                 }   
             }
         }
-    }
+
+        // Cleanup all those UFCallTerm copies.  FIXME: yuck!
+        //for (i = ufCallTerms.begin(); i!=ufCallTerms.end(); i++) {
+        //    UFCallTerm* ufCall1 = (*i);
+        //    delete ufCall1;
+        //}
+
+    } // loop over Conjuncts
 }
 
 

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -16,6 +16,8 @@
 #include "set_relation.h"
 #include "Visitor.h"
 #include "TermPartOrdGraph.h"
+#include <stack>
+#include <map>
 #include <assert.h>
 
 namespace iegenlib{
@@ -2807,10 +2809,16 @@ Relation* Relation::addUFConstraints(std::string uf1str,
 class VisitorCollectTerms : public Visitor {
   private:
     TermPartOrdGraph        mPartOrd;
-    Term*                   mNonConstTerm; // will be NULL if none or >1
-    int                     mNumNonConstTerms;
-    int                     mConstTermVal;
-    bool                    mInUFArg;
+    
+    // FIXME: Don't need maps here.  No nesting of equality and inequality
+    // expressions in each other.
+    std::map<Exp*,Term*>    mNonConstTerm; // will be NULL if none or >1
+    std::map<Exp*,int>      mNumNonConstTerms;
+    std::map<Exp*,int>      mConstTermVal;
+    
+    // Do need a stack of expressions.  Within inequality and equality
+    // expressions there can be nested uninterpreted function param exps.
+    std::stack<Exp*>        mCurrExpStack;
     
   public:
     VisitorCollectTerms() {}
@@ -2819,14 +2827,11 @@ class VisitorCollectTerms : public Visitor {
     TermPartOrdGraph returnPartOrd() { return mPartOrd; }
 
     void postVisitTerm(iegenlib::Term * t) {
-        mConstTermVal = t->coefficient();
+        mConstTermVal[mCurrExpStack.top()] = t->coefficient();
     }
     void postVisitUFCallTerm(iegenlib::UFCallTerm * t) {
         mPartOrd.insertTerm(t);
         nonConstTerm(t);
-        //iegenlib::queryInverseCurrEnv("f")
-        // Don't I have a routine that puts in all the
-        // constraints due to domain and range?
     }
     void postVisitTupleVarTerm(iegenlib::TupleVarTerm * t) {
         mPartOrd.insertTerm(t);
@@ -2843,33 +2848,33 @@ class VisitorCollectTerms : public Visitor {
     }
 */    
     void preVisitExp(iegenlib::Exp * e) {
-        mNonConstTerm = NULL;
-        mNumNonConstTerms = 0;
-        mConstTermVal = 0;
-        // Can only determine non-negative property for terms in
-        // equality and inequality constraints.  See nonConstTerm().
-        if (!e->isEquality() && !e->isInequality()) {
-            mInUFArg = true;
-        } else {
-            mInUFArg = false;
-        }
+        mCurrExpStack.push(e);
+        mNonConstTerm[e] = NULL;
+        mNumNonConstTerms[e] = 0;
+        mConstTermVal[e] = 0;
     }
     void postVisitExp(iegenlib::Exp * e) {
         if ((e->isEquality() || e->isInequality())
-                && mNonConstTerm!=NULL && mConstTermVal>=0) {
-            mPartOrd.termNonNegative( mNonConstTerm );
+                && mNonConstTerm[e]!=NULL && mConstTermVal[e]>=0) {
+            mPartOrd.termNonNegative( mNonConstTerm[e] );
         }
+        mCurrExpStack.pop();
     }
 
 private:
     // Called when visiting each non-const term.  If only
     // end up with 1 non-const term, then the postVisitExp will determine
     // if that non constant term is non-negative.
-    void nonConstTerm(const iegenlib::Term* t) {
-        if (!mInUFArg) {
-            mNumNonConstTerms++;
-            if (mNumNonConstTerms>0) {
-                mNonConstTerm = NULL;
+    // Method does not take on ownership of t.
+    void nonConstTerm(iegenlib::Term* t) {
+        Exp* e = mCurrExpStack.top();
+        if (e->isEquality() || e->isInequality()) {
+            mNumNonConstTerms[e]++;
+            // we are current candidate for only term
+            mNonConstTerm[e] = t;
+            // unless there are others
+            if (mNumNonConstTerms[e]>1) {
+                mNonConstTerm[e] = NULL;
             }
         }
     }
@@ -2913,39 +2918,40 @@ class VisitorCollectPartOrd : public Visitor {
   private:
     bool                    mFoundNonNeg;
     TermPartOrdGraph        mPartOrd;
-    Exp*                    mCurrExp;
+    
+    // Do need a stack of expressions.  Within inequality and equality
+    // expressions there can be nested uninterpreted function param exps.
+    std::stack<Exp*>        mCurrExpStack;
     
   public:
     VisitorCollectPartOrd(TermPartOrdGraph partOrd) :
-        mFoundNonNeg(false), mPartOrd(partOrd), mCurrExp(NULL) {}
+        mFoundNonNeg(false), mPartOrd(partOrd) {}
     ~VisitorCollectPartOrd() {}
   
     bool hasConverged() { return !mFoundNonNeg; }
     TermPartOrdGraph returnPartOrd() { return mPartOrd; }
 
     void preVisitExp(iegenlib::Exp * e) {
-        if (e->isEquality() || e->isInequality()) {
-            mCurrExp = e;
-            mFoundNonNeg = false;
-        }
+        mCurrExpStack.push(e);
     }
     void postVisitExp(iegenlib::Exp * e) {
-        if (e->isEquality() || e->isInequality()) {
-            mCurrExp = NULL;
-        }
+        mCurrExpStack.pop();
+    }
+    void preVisitConjunction(iegenlib::Conjunction * conjunct) {
+        mFoundNonNeg = false; // reinitialize at beginning of each conjunct
     }
 
     // See class header for logic.
     void deriveInfo(iegenlib::Term * t) {
+        Exp* e = mCurrExpStack.top();
+        
         // solve for factor treats the constraint like exp=0
         Term * t_with_coeff_1 = t->clone();
         t_with_coeff_1->setCoefficient(1);
-        Exp *solution = mCurrExp->solveForFactor(t_with_coeff_1);
+        Exp *solution = e->solveForFactor(t_with_coeff_1);
 
         // No info to derive if can't solve for term.
         if (solution==NULL) return;
-
-std::cout << "deriveInfo, t = " << t->toString() << ", mCurrExp = " << mCurrExp->toString() << ", solution = " << solution->toString() << std::endl;
 
         // Whether we have equality or inequality with t having a positive
         // coefficient (t + ... >=0), if all the terms in
@@ -2956,10 +2962,9 @@ std::cout << "deriveInfo, t = " << t->toString() << ", mCurrExp = " << mCurrExp-
             mPartOrd.termNonNegative(t);
             mFoundNonNeg = true;
         }
-std::cout << "deriveInfo, mFoundNonNeg = " << mFoundNonNeg << std::endl;
 
         // If the constraint is an equality
-        if (mCurrExp->isEquality()) {   
+        if (e->isEquality()) {   
             // and there is only one other term in the solution with coeff 1,
             // then this term is equal to the solution term.
             Term* singleTerm = solution->getTerm();
@@ -2971,25 +2976,16 @@ std::cout << "deriveInfo, mFoundNonNeg = " << mFoundNonNeg << std::endl;
         }
 
         // If the constraint is an inequality (exp>=0)
-        if (mCurrExp->isInequality()) {
+        if (e->isInequality()) {
         
-            // Was this term's coefficient positive or negative originally?
-//            bool posCoeffForTerm = (t->coefficient()>0);
-            
              // Get the constant in the solution.
             Term* constTerm = solution->getConstTerm();
             int c = (constTerm ? constTerm->coefficient() : 0);  
-
-
-/* DON't want this.  Can't do part ord when coeff in solution are neg.           
-            // How many non constant terms are in the solution?
-            // If constant is zero, then won't have an explicit
-            // constant terms (ASSUMPTION)
-            int non_const_terms=(c==0?termList->size():termList->size()-1);
-*/
      
             // We want to iterate over the solution terms if
             // the solution has all non negative terms.
+            // Can't determine a partial ordering when any coeffs
+            // in the solution are negative.
             if (termsNonNeg(solution,mPartOrd)) {
             
                 // Iterate over the list of terms in the solution.
@@ -3004,30 +3000,26 @@ std::cout << "deriveInfo, mFoundNonNeg = " << mFoundNonNeg << std::endl;
                     // t >= solution_term + (other noneg terms) + c, c>=1
                     if (c>=1 && t->coefficient()>0) {
                         mPartOrd.insertLT(solution_term, t);
-//std::cout << "deriveInfo, mPartOrd.insertLT(solution_term, t);" << std::endl;
 
                     // t <= solution_term + (other noneg terms) + c, c>=1
                     } else if (c>=1 && t->coefficient()<0) {
                         mPartOrd.insertLT(t, solution_term);
-//std::cout << "deriveInfo, mPartOrd.insertLT(t,solution_term);" << std::endl;
 
                     // t >= solution_term + (other noneg terms) + c, c==0
                     } else if (c==0 && t->coefficient()>0) {
                         mPartOrd.insertLTE(solution_term, t);
-//std::cout << "deriveInfo, mPartOrd.insertLTE(solution_term, t);" << std::endl;
 
                    // t <= solution_term + (other noneg terms) + c, c==0
                     } else if (c==0 && t->coefficient()<0) {
                         mPartOrd.insertLTE(t, solution_term);
-//std::cout << "deriveInfo, mPartOrd.insertLTE(t,solution_term);" << std::endl;
                     }
                 }
             } // endif termsNonNeg(solution,mPartOrd)
             
-        } // endif mCurrExp->isInequality()
+        } // endif e->isInequality()
 
-std::cout << "deriveInfo, end of method, mPartOrd = " << mPartOrd.toString() << std::endl;
-        
+std::cout << "mPartOrd = " << mPartOrd.toString() << std::endl;
+
     }
 
     void postVisitTerm(iegenlib::Term * t) {
@@ -3054,6 +3046,7 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
     // can be added to the specific conjunction.
     // Has be be by conjunction because might use information about what
     // terms are non-zero in a conjunction.
+    // FIXME: can the visitor visit each conjunction instead of us looping?
     for (std::list<Conjunction*>::iterator iter=mConjunctions.begin();
             iter != mConjunctions.end(); iter++) {
 
@@ -3063,7 +3056,6 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
         VisitorCollectTerms v1;
         conjunct->acceptVisitor(&v1);
         TermPartOrdGraph partOrd = v1.returnPartOrd();
-std::cout << "after VisitorCollectTerms, partOrd = " << partOrd.toString() << std::endl;
 
         // Indicate we are done adding terms into the partial ordering.
         partOrd.doneInsertingTerms();
@@ -3073,10 +3065,11 @@ std::cout << "after VisitorCollectTerms, partOrd = " << partOrd.toString() << st
         // which impacts partial orderings, has converged.
         VisitorCollectPartOrd v2(partOrd);
         do {
-std::cout << "in do while loop" << std::endl;
             conjunct->acceptVisitor(&v2);
         } while (!(v2.hasConverged()));
         partOrd = v2.returnPartOrd();
+std::cout << "partOrd = " << partOrd.toString() << std::endl;
+    
 
         // For each UFCall term that involves monotonically non-decreasing
         // function, put in new constraints that can be derived based on
@@ -3088,7 +3081,7 @@ std::cout << "in do while loop" << std::endl;
             for (j = ufCallTerms.begin(); j!=ufCallTerms.end(); j++) {
                 UFCallTerm* ufCall1 = (*i);
                 UFCallTerm* ufCall2 = (*j);
-std::cout << "ufCall1 = " << ufCall1->toString() << ", ufCall2 = " << ufCall2->toString() << std:: endl;
+
                 if (ufCall1->name()==ufCall2->name()
                         && ufCall1->numArgs()==1
                         && ufCall2->numArgs()==1
@@ -3104,16 +3097,20 @@ std::cout << "ufCall1 = " << ufCall1->toString() << ", ufCall2 = " << ufCall2->t
                     new_constraint->addExp(smallerExp);
                     new_constraint->addExp(ufCall2->getParamExp(0)->clone());
 
+std::cout << "partOrd.isLT(ufCall1,ufCall2) = " << partOrd.isLT(ufCall1,ufCall2) << std::endl;
                     // if ufCall1(e1) < ufCall2(e2) then e1 < e2
                     if (partOrd.isLT(ufCall1,ufCall2)) {
                         // largerTerm - smallerTerm - 1 >= 0
                         new_constraint->addTerm(new Term(-1));
                         conjunct->addInequality(new_constraint);
+std::cout << "new_constraint being added = " << new_constraint->toString() << std:: endl;
                         
                     // if ufCall1(e1) <= ufCall2(e2) then e1 <= e2
                     } else if (partOrd.isLTE(ufCall1,ufCall2)) {
                         // largerTerm - smallerTerm >= 0
                         conjunct->addInequality(new_constraint);
+std::cout << "new_constraint being added = " << new_constraint->toString() << std:: endl;
+                        
                     } else {
                         delete new_constraint;
                     }
@@ -3128,7 +3125,7 @@ Set* Set::addConstraintsDueToMonotonicity() const {
     Set* retval = new Set(*this);
     
     // Add in constraints due to domain and range.
-    // FIXME: not happy about how this works now.
+    // FIXME: not happy about how this works now.  Mahdi is fixing.
 //    UFCallMapAndBounds ufcallmap(getTupleDecl());
 //    retval->ufCallsToTempVars(ufcallmap);
 //std::cout << "After ufCallsToTempVars, retval = " << retval->toString() << std::endl;

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -2658,7 +2658,7 @@ void Relation::acceptVisitor(Visitor *v) {
 
 
 /******************************************************************************/
-#pragma mark -
+#pragma mark addUFConstraints
 /****************** addUFConstraints ******************************************/
 
 class VisitorFindUFCallTerms : public Visitor {
@@ -2798,7 +2798,7 @@ Relation* Relation::addUFConstraints(std::string uf1str,
 }
 
 /******************************************************************************/
-#pragma mark -
+#pragma mark addConstraintsDueToMonotonicity
 /*************** addConstraintsDueToMonotonicity ******************************/
 /*! This visitor will collect all of the terms except for constants
     from the constraints and will indicate which of the terms are
@@ -3114,12 +3114,6 @@ void SparseConstraints::addConstraintsDueToMonotonicityHelper() {
                 }   
             }
         }
-
-        // Cleanup all those UFCallTerm copies.  FIXME: yuck!
-        //for (i = ufCallTerms.begin(); i!=ufCallTerms.end(); i++) {
-        //    UFCallTerm* ufCall1 = (*i);
-        //    delete ufCall1;
-        //}
 
     } // loop over Conjuncts
 }

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -535,7 +535,7 @@ public:
 
     //! Adds constraints due to domain and range of all UFCalls in UFCallmap
     //  Users own the returned Set object.
-    Set* boundDomainRange();
+    Set* boundDomainRange() const;
 
     //! Creates a super affine set from a non-affine set.
     //  To do this:
@@ -686,7 +686,7 @@ public:
 
     //! Adds constraints due to domain and range of all UFCalls in UFCallmap
     //  Users own the returned Relation object.
-    Relation* boundDomainRange();
+    Relation* boundDomainRange() const;
 
     //! Creates a super affine Relation from a non-affine Relation.
     //  To do this:

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3546,35 +3546,28 @@ TEST_F(SetRelationTest, addConstraintsDueToMonotonicity){
     delete expected;
     }
 
+    iegenlib::appendCurrEnv("g",
+        new Set("{[i]:0<=i &&i<G}"), new Set("{[i]:0<=i &&i<G}"), false,
+        iegenlib::Monotonic_Increasing);
+
+    {
+    Set* s = new Set("{[i,j] : g(i)<g(j) && 0<=g(i) && 0<=g(j)}");
+    Set* result = s->addConstraintsDueToMonotonicity();
+    Set* expected = new Set("{[i,j] : g(i) >= 0 && g(j) >= 0 && "
+                            "g(i)<G && g(j)<G && "
+                            "0<=i && i<G && 0<=j && j<G &&"
+                            "g(i)<g(j) && i<j}");
+                            
+    EXPECT_EQ(expected->prettyPrintString(), result->prettyPrintString());
+    
+    delete s;
+    delete result;
+    delete expected;
+    }
+
+
   }
-/*
-  {
-    Relation* r = new Relation("{[i,j]->[k] : index(i) <= j && "
-        "j < index(i+1) && diagptr(v+1)<k && k<indexptr(i)}");
-    
-    Relation* result1 = r->addUFConstraints("index",">", "diagptr");
-    
-    EXPECT_EQ("{ [i, j] -> [k] : j - index(i) >= 0 && -j + index(i + 1) "
-              "- 1 >= 0 && -k + indexptr(i) - 1 >= 0 && k - diagptr(v + "
-              "1) - 1 >= 0 && -diagptr(i) + index(i) + 1 >= 0 && -diagpt"
-              "r(i + 1) + index(i + 1) + 1 >= 0 && -diagptr(v + 1) + ind"
-              "ex(v + 1) + 1 >= 0 }",
-              result1->prettyPrintString());
 
-    Relation* result2 = r->addUFConstraints("index","=", "diagptr");
-
-    EXPECT_EQ("{ [i, j] -> [k] : diagptr(i) - index(i) = 0 && diagptr(i + "
-              "1) - index(i + 1) = 0 && diagptr(v + 1) - index(v + 1) = 0 "
-              "&& j - index(i) >= 0 && -j + index(i + 1) - 1 >= 0 && -k + "
-              "indexptr(i) - 1 >= 0 && k - diagptr(v + 1) - 1 >= 0 }",
-              result2->prettyPrintString());
-
-    
-    delete r;
-    delete result1;
-    delete result2;
-  }
-*/ 
 }
 
 

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3516,16 +3516,36 @@ TEST_F(SetRelationTest, addConstraintsDueToMonotonicity){
         new Set("{[i]:0<=i &&i<G}"), new Set("{[i]:0<=i &&i<G}"), false,
         iegenlib::Monotonic_Nondecreasing);
 
+    {
     Set* s = new Set("{[i,j] : f(i)<f(j) && 0<=f(i) && 0<=f(j)}");
     Set* result = s->addConstraintsDueToMonotonicity();
     Set* expected = new Set("{[i,j] : f(i) >= 0 && f(j) >= 0 && "
+                            "f(i)<G && f(j)<G && "
+                            "0<=i && i<G && 0<=j && j<G &&"
                             "f(i)<f(j) && i<j}");
     
     EXPECT_EQ(expected->prettyPrintString(), result->prettyPrintString());
-
+    
     delete s;
     delete result;
     delete expected;
+    }
+    
+    {
+    Set* s = new Set("{[i,j] : f(i)<f(j) && 0<=f(i) && 0<=f(j)}");
+    Set* result = s->addConstraintsDueToMonotonicity();
+    Set* expected = new Set("{[i,j] : f(i) >= 0 && f(j) >= 0 && "
+                            "f(i)<G && f(j)<G && "
+                            "0<=i && i<G && 0<=j && j<G &&"
+                            "f(i)<f(j) && i<j}");
+                            
+    EXPECT_EQ(expected->prettyPrintString(), result->prettyPrintString());
+    
+    delete s;
+    delete result;
+    delete expected;
+    }
+
   }
 /*
   {

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3516,15 +3516,16 @@ TEST_F(SetRelationTest, addConstraintsDueToMonotonicity){
         new Set("{[i]:0<=i &&i<G}"), new Set("{[i]:0<=i &&i<G}"), false,
         iegenlib::Monotonic_Nondecreasing);
 
-    Set* s = new Set("{[i,j] : f(i)<f(j)}");
+    Set* s = new Set("{[i,j] : f(i)<f(j) && 0<=f(i) && 0<=f(j)}");
     Set* result = s->addConstraintsDueToMonotonicity();
-    Set* expected = new Set("{[i,j] : f(i)<f(j) && i<j}");
+    Set* expected = new Set("{[i,j] : f(i) >= 0 && f(j) >= 0 && "
+                            "f(i)<f(j) && i<j}");
     
     EXPECT_EQ(expected->prettyPrintString(), result->prettyPrintString());
 
-    //delete s;
-    //delete result;
-    //delete expected;
+    delete s;
+    delete result;
+    delete expected;
   }
 /*
   {

--- a/src/util/PartOrdGraph.cc
+++ b/src/util/PartOrdGraph.cc
@@ -63,7 +63,13 @@ PartOrdGraph::PartOrdGraph(const PartOrdGraph& other) {
 //! Copy assignment.
 PartOrdGraph& PartOrdGraph::operator=(const PartOrdGraph& other) {
     mN = other.mN;
-    *mAdjacencyMatrix = *(other.mAdjacencyMatrix);
+    this->mAdjacencyMatrix = new CompareEnum[mN*mN];
+    for (int i=0; i<mN; i++) {
+        for (int j=0; j<mN; j++) {
+            mAdjacencyMatrix[getIndex(i,j)]
+                = other.mAdjacencyMatrix[getIndex(i,j)];
+        }
+    }
     return *this;
 }
 


### PR DESCRIPTION
We are now adding constraints for expressions passed into monotonically increasing or non-decreasing functions based on partial orderings we can discover about UF calls.
