### PR TITLE
New projectOut

### DIFF
--- a/src/set_relation/expression.h
+++ b/src/set_relation/expression.h
@@ -351,6 +351,8 @@ public:
     // Returns location of TV 
     int tvloc(){return mLocation;}
 
+    void setTvloc(int nl){ mLocation = nl;}
+
     //--------------------- methods for the use in expression
 
     //! Returns true if this term has the same factor (i.e. everything

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -85,12 +85,10 @@ public:
     //! Comparison operator -- lexicographic order
     bool operator<(const Conjunction& other) const;
 
-/*
-	//! Given inarity parameter is adopted.
-	//! If inarity parameter is outside of feasible range for the existing
-	//! existing TupleDecl then throws exception.
+    //! Given inarity parameter is adopted.
+    //! If inarity parameter is outside of feasible range for the existing
+    //! existing TupleDecl then throws exception.
     void setInArity(int inarity);
-*/
     
     //! Given tuple declaration parameter is adopted.
     //! If there are some constants that don't agree then throws exception.
@@ -163,7 +161,6 @@ public:
     int arity() const { return mTupleDecl.size(); }
     //! Get/Set inarity, for use with relations
     int inarity() const { return mInArity; }
-    void setinarity(int in) { mInArity = in; }
     
     //! Returns true if the conjunction has at least one equality or inequality
     //! constraints.  If it contains none then this Conjunction is just


### PR DESCRIPTION
Project out is changed to work with new functions that use Visitor approach. The old project out is removed. However, the interface stayed exactly the same.

Description:
We divide the constraint sets into two groups:  (1) targetConst: Those constraints that have tvar in them. Therefore, we need to project out tvar from these constraints. (2) otherConst:  Those constraints that do not have tvar in them. Therefore, we are going to leave unchanged. For each conjunction, we first find these two groups, and  put them into separate conjunctions. Then, we use ISL library to project out tvar from "targetConst". Finally, we intersect the new conjunction with "otherConst" to get the final result.

There are two reasons for separating constraints: (1) ISL does some replacement for equality constraint and some simplification that is not exactly deterministic. Old project out would have failed for some types of constraints. The reason was related to this ISL behavior. (2) If we decide to implement project out ourself, changing this implementation would be much easier.
