### PR TITLE
Islinteraction cleanup

### DIFF
--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -57,7 +57,7 @@ std::string islSetToString ( isl_set* iset , isl_ctx *ctx )
   return stringFromISL;
 }
 
-//! This function takes a Relation string and returns equivalent isl_map*
+//! This function takes a Relation string and returns pointer to equ. isl_map
 isl_map* islStringToMap( std::string relstr , isl_ctx *ctx )
 {
   // load Relation r into ISL map
@@ -66,8 +66,8 @@ isl_map* islStringToMap( std::string relstr , isl_ctx *ctx )
   return imap;
 }
 
-/*! This function takes an isl_map* and returns equivalent Relation string
-** The function takes ownership of input argument 'iset'
+/*! This function takes an isl_map* and returns pointer to equ. Relation string
+** The function takes ownership of input argument 'imap'
 */
 std::string islMapToString ( isl_map* imap , isl_ctx *ctx )
 {
@@ -102,7 +102,7 @@ string passSetThruISL(string rstr) {
   return result;
 }
 
-//! runs the Relatioin through ISL and returns the resulting string
+//! Runs a Relation string through ISL and returns the resulting string
 string passRelationThruISL(string rstr) {
 
   isl_ctx *ctx = isl_ctx_alloc();

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -3739,11 +3739,9 @@ class VisitorSuperAffineSet : public Visitor {
 */
 Set* Set::superAffineSet(UFCallMap* ufcmap)
 {
-    Set* copySet = new Set( this->toISLString() );
-    VisitorSuperAffineSet* v = new VisitorSuperAffineSet(ufcmap);
-    
-    copySet = copySet->boundDomainRange();
+    Set* copySet = this->boundDomainRange();
 
+    VisitorSuperAffineSet* v = new VisitorSuperAffineSet(ufcmap);
     copySet->acceptVisitor( v );
     
     Set* result = (v->getSet());
@@ -3757,11 +3755,9 @@ Set* Set::superAffineSet(UFCallMap* ufcmap)
 //! Same as Set
 Relation* Relation::superAffineRelation(UFCallMap* ufcmap)
 {
-    Relation* copyRelation = new Relation( inArity(), outArity());
-    VisitorSuperAffineSet* v = new VisitorSuperAffineSet(ufcmap);
-    
-    copyRelation = this->boundDomainRange();
+    Relation* copyRelation = this->boundDomainRange();
 
+    VisitorSuperAffineSet* v = new VisitorSuperAffineSet(ufcmap);
     copyRelation->acceptVisitor( v );
 
     Relation* result = (v->getRelation());
@@ -3890,17 +3886,11 @@ class VisitorReverseAffineSubstitution : public Visitor {
 */
 Set* Set::reverseAffineSubstitution(UFCallMap* ufcmap)
 {
-    Set* copySet = new Set( this->toISLString() );
     VisitorReverseAffineSubstitution* v = 
                   new VisitorReverseAffineSubstitution(ufcmap);
-    
-    copySet = copySet->boundDomainRange();
-
-    copySet->acceptVisitor( v );
+    this->acceptVisitor( v );
     
     Set* result = (v->getSet());
-    
-    delete copySet;
     delete v;
 
     return result;
@@ -3909,16 +3899,11 @@ Set* Set::reverseAffineSubstitution(UFCallMap* ufcmap)
 //! Same as Set
 Relation* Relation::reverseAffineSubstitution(UFCallMap* ufcmap)
 {
-    Relation* copyRelation = new Relation( inArity(), outArity());
-    VisitorReverseAffineSubstitution* v = new VisitorReverseAffineSubstitution(ufcmap);
-    
-    copyRelation = this->boundDomainRange();
-
-    copyRelation->acceptVisitor( v );
+    VisitorReverseAffineSubstitution* v = 
+                  new VisitorReverseAffineSubstitution(ufcmap);
+    this->acceptVisitor( v );
 
     Relation* result = (v->getRelation());
-
-    delete copyRelation;
     delete v;
 
     return result;


### PR DESCRIPTION
These functions were added:

(1) islStringToMap(): This function takes a Relation string and returns equ pointer to ivalent isl_map
(2) islMapToString(): This function takes an isl_map\* and returns pointer to equ. Relation string
(3) passRelationThruISL: Runs a Relation string through ISL and returns the resulting string

One function's name changed: from “getStringFromISL” to “passSetThruISL”

Additionally, some extra code and memory leaks removed from "superAffineSet" and "reverseAffineSubstitution"
