### PR TITLE
new projectOut

### DIFF
--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -244,17 +244,15 @@ bool Conjunction::operator<( const Conjunction& other) const {
 
 }
 
-/*
 //! Given inarity parameter is adopted.
 //! If inarity parameter is outside of feasible range for the existing
 //! existing TupleDecl then throws exception.
 void Conjunction::setInArity(int inarity) {
- 	if (inarity < 0 || inarity > (mTupleDecl.size()-1) ) {
+ 	if (inarity < 0 || inarity > int(mTupleDecl.size()-1) ) {
         throw assert_exception("Conjunction::setInArity: impossible arity match");
 	}
 	mInArity = inarity;
 }
-*/
 
 //! If there are some constants that don't agree then throws exception.
 //! If replacing a constant with a variable ignores the substitution
@@ -2893,205 +2891,6 @@ bool SparseConstraints::isUFCallParam(int tupleID) {
 
 /*****************************************************************************/
 #pragma mark -
-/*************** VisitorProjectOut *****************************/
-// Vistor Class used in projection process
-class VisitorProjectOut : public Visitor {
-  private:
-    int tvar;
-    int in_ar;
-
-  public:
-    VisitorProjectOut(int tvarI){ tvar = tvarI; in_ar = 0; }
-    virtual ~VisitorProjectOut(){ }
-    void preVisitConjunction(iegenlib::Conjunction * c);
-    void preVisitRelation(iegenlib::Relation * r);
-
-};
-
-//   Projects out tuple varrable No. tvar from Conjunction
-void VisitorProjectOut::preVisitConjunction(iegenlib::Conjunction * c)
-{
-    Conjunction* selfcopy = new Conjunction(*c);
-    TupleDecl origTupleDecl = selfcopy->getTupleDecl(); // for (step 3)
- 
-    /////////////////////
-    // (step 1) Replace all uninterpreted function calls with temp
-    // variables and create a new affine conjunction that is a superset
-    // of the current conjunction.  UFCallMapAndBounds object will
-    // maintain the mapping of temporary variables to UF calls.
-    UFCallMapAndBounds ufcallmap(origTupleDecl);
-    selfcopy->ufCallsToTempVars( ufcallmap );
-
-    Set* constraints = ufcallmap.cloneConstraints();
-
-    // update the tuple declaration in selfcopy to match what is
-    // in the constraints
-    selfcopy->setTupleDecl( constraints->getTupleDecl() );
-    
-    // Also need to include all the constraints in selfcopy where UF calls
-    // were replaced by temporaries.
-    Set* selfcopyset = new Set(selfcopy->getTupleDecl());
-    selfcopyset->addConjunction(selfcopy);
-
-    Set* retval1 = constraints->Intersect(selfcopyset);
-    
-    //////////////////////
-    // (step 2) Send the result of step 1 to ISL and back.
-
-    // (a) get string from result of step 1
-    std::string fromStep1 = retval1->toISLString();
- 
-    // (b) send through ISL to project out desired tuple variable
-    string fromISL = islSetProjectOut(fromStep1, tvar);
-
-    // (c) convert back to a Set
-    Set* retval2 = new Set(fromISL);
-
-    delete retval1;
-
-    /////////////////////
-    // (step 3) In (step 3) we will need to use substitute to replace
-    // extra tuple vars with UF calls by making queries to ufcallmap. Will
-    // need to call setTupleDecl on retval to remove those extra tuple vars
-    // that acted as temporaries to replace uf calls. Then return retval Set.
-    
-    // Determine starting index of extra tuple vars
-    int numTempVars = ufcallmap.numTempVars();
-    int expandedArity = (retval2->mConjunctions.front())->arity();
-    int indexStart = expandedArity - numTempVars;
-
-    SubMap affineSubstMap;
-    // Taking into account projection effect on tuple variable order:
-    // tv_n -> tv_n-1;  tv_n-1 -> tv_n-2; ... tv_tvar+1 -> tv_tvar
-    for (int i = tvar; i < expandedArity; i++) {
-
-    	TupleVarTerm* tvTerm = new TupleVarTerm(i+1);
-    	TupleVarTerm* tvTermJ = new TupleVarTerm(i);
-        Exp * tvExp = new Exp();
-        tvExp->addTerm(tvTermJ);
-
-        // Add this equivalence to affineSubstMap
-        affineSubstMap.insertPair(tvTerm,tvExp);
-    } 
-    	    
-    // Build up a map of non-affine information, we substituted them back in. 
-    SubMap nonAffineSubstMap;
-
-    for (int i = indexStart; i < expandedArity; i++) {
-
-      // considering projected out variable
-      int j;
-      if (i >= tvar){
-        j = i+1;
-      }
-      else {
-        j = i;
-      }
-
-      TupleVarTerm* tvTerm = new TupleVarTerm(i);
-      UFCallTerm* origUFCall = ufcallmap.cloneUFCall(j);
-      Exp* tvExp = new Exp();
-      tvExp->addTerm(origUFCall);
-
-      // substitute affine results into original UFCall
-      tvExp->substitute(affineSubstMap);
-		
-      // substitute non-affine results into original UFCall
-      tvExp->substitute(nonAffineSubstMap);
-
-      nonAffineSubstMap.insertPair(tvTerm, tvExp);
-    }
-
-    // SubstituteInConstraints using non-affine SubMap
-    retval2->substituteInConstraints(nonAffineSubstMap);
-    
-   // Remove extra tuple vars (since they have been "substituted", and 
-   // we have removed one tuple variable
-   TupleDecl redTupleDecl(origTupleDecl.size()-1);
-   for (int i = 0; i < int(redTupleDecl.size()) ; i++) {
-      // considering projected out variable
-      int j;
-      if (i >= tvar){
-        j = i+1;
-      }
-      else {
-        j = i;
-      }
-     redTupleDecl.setTupleElem(i , origTupleDecl.elemVarString(j));
-   }
-
-//std::cout<<std::endl<<"tuple shrink = "<<redTupleDecl.toString()<<std::endl;
-    retval2->setTupleDecl(redTupleDecl);
-//std::cout<<"After tuple shrink = "<<retval2->prettyPrintString()<<std::endl;
-
-    *c = *(retval2->mConjunctions.front());
-    c->setinarity( in_ar );
-
-    delete constraints;
-    delete selfcopy;
-    delete retval2;
-}
-
-// This function sets the in/out arity of the relation to
-// new values of after project out 
-void VisitorProjectOut::preVisitRelation(iegenlib::Relation * r)
-{
-    int ia = r->inArity();
-    int oa = r->outArity();
-    if (tvar < ia){
-      ia--;
-    }
-    else {
-      oa--;
-    }
-    r->SetinArity(ia);
-    r->SetoutArity(oa);
-
-    in_ar = ia;
-}
-
-//   Projects out tuple varrable No. tvar starting from 0
-Set* Set::projectOut(int tvar)
-{
-    if (isUFCallParam(tvar)){
-      return NULL;
-    }
-
-    Set *s = new Set(*this);
-    VisitorProjectOut * v = new VisitorProjectOut(tvar);
-    s->acceptVisitor(v);
-
-    Set *result = new Set(*s);
-    delete s;
-    delete v;
-
-    return result;
-}
-
-/*   Projects out tuple varrable No. tvar
-     tvar is calculated based on total ariety (in+out) starting from 0.
-     Consequently, to project out jp from R: tvar = 5
-     R = {[i,j,k] -> [ip,jp,kp] : ...}
-*/
-Relation* Relation::projectOut(int tvar)
-{
-    if (isUFCallParam(tvar)){
-      return NULL;
-    }
-
-    Relation *r = new Relation(*this);
-    VisitorProjectOut * v = new VisitorProjectOut(tvar);
-    r->acceptVisitor(v);
-
-    Relation *result = new Relation(*r);
-    delete r;
-    delete v;
-
-    return result;
-}
-
-/*****************************************************************************/
-#pragma mark -
 /*************** VisitorUFCtoParamVar *****************************/
 // Vistor Class used in traversing conjunctions for finding UFCalls
 class VisitorUFCtoParamVar : public Visitor {
@@ -3147,7 +2946,7 @@ class VisitorBoundDomainRange : public Visitor {
          void postVisitConjunction(iegenlib::Conjunction * c){
              Conjunction *ct = c->Intersect( addedConstSet->mConjunctions.front() );
              *c = *ct;
-             c->setinarity( in_ar );
+             c->setInArity( in_ar );
              delete addedConstSet;
              delete ct;
          }
@@ -3353,7 +3152,7 @@ class VisitorSuperAffineSet : public Visitor {
          //! Initializes an affineConj
          void preVisitConjunction(iegenlib::Conjunction * c){
              affineConj = new Conjunction( c->getTupleDecl() );
-             affineConj->setinarity( c->inarity() );
+             affineConj->setInArity( c->inarity() );
          }
          //! adds the current affineConj to maffineConj
          void postVisitConjunction(iegenlib::Conjunction * c){
@@ -3502,7 +3301,7 @@ class VisitorReverseAffineSubstitution : public Visitor {
          //! Initializes an nonAffineConj
          void preVisitConjunction(iegenlib::Conjunction * c){
              nonAffineConj = new Conjunction( c->getTupleDecl() );
-             nonAffineConj->setinarity( c->inarity() );
+             nonAffineConj->setInArity( c->inarity() );
          }
          //! adds the current nonAffineConj to nonMAffineConj
          void postVisitConjunction(iegenlib::Conjunction * c){
@@ -3560,5 +3359,196 @@ Relation* Relation::reverseAffineSubstitution(UFCallMap* ufcmap)
 
     return result;
 }
+
+
+
+/*****************************************************************************/
+#pragma mark -
+/*************** VisitorProjectOut *****************************/
+//! Vistor Classes used in projection process
+
+/*! The main class for projecting out tuple variables from affine Set/Relation
+**  We use ISL library to project out tvar from each conjunction
+*/
+class VisitorProjectOut : public Visitor {
+  private:
+    int tvar;
+    int inArity;
+    Set* newSet;
+    Relation* newRelation;
+    std::list<Conjunction*> mNewConj;
+  public:
+    VisitorProjectOut(int itvar, int ia=0){
+        tvar = itvar;
+        // Adjust inArity for after projection
+        if( tvar < ia && ia != 0 ){
+            ia--;
+        } 
+        inArity = ia;
+    }
+    // Projects out tuple varrable No. tvar from current conjunction
+    // And adds it to mNewConj
+    void postVisitConjunction(iegenlib::Conjunction* c){
+        Conjunction* targetConst = new Conjunction( *c );
+        
+        targetConst->setInArity(0);
+        Set * cs = new Set(targetConst->arity() );
+        cs->addConjunction(targetConst);
+
+        // Use ISL to project out tuple variable.
+        // (a) get string from conjunction
+        std::string conjString = cs->toISLString();
+
+        // (b) send through ISL to project out desired tuple variable
+        string fromISL = islSetProjectOut(conjString, tvar);
+
+        // (c) convert back to a Conjunction
+        Set* islSet = new Set(fromISL);
+        Conjunction* crc = new Conjunction ( *(islSet->mConjunctions.front()) );
+        crc->setInArity( inArity );
+
+        // Storing the result so we could add it to new Set or Relation later.
+        mNewConj.push_back( crc );
+
+        delete islSet;
+        delete cs;
+    }
+    //! Add Conjunctions in mnewConj to newSet
+    void postVisitSet(iegenlib::Set * s){
+        newSet = new Set( (s->arity()-1) );
+
+        for(std::list<Conjunction*>::const_iterator i=mNewConj.begin();
+                      i != mNewConj.end(); i++) {
+            newSet->addConjunction((*i));
+        }
+    }
+    //! Add Conjunctions in mnewConj to newRelation
+    void postVisitRelation(iegenlib::Relation * r){
+        // Adjusting new in and out arity depending projected tvar 
+        int ia = r->inArity(), oa = r->outArity();
+        if( tvar < ia ){
+            ia--;
+        } else {
+            oa--;
+        }
+        newRelation = new Relation( ia , oa );
+
+        for(std::list<Conjunction*>::const_iterator i=mNewConj.begin();
+                     i != mNewConj.end(); i++) {
+
+            newRelation->addConjunction((*i));
+        }
+    }
+
+    Set* getSet(){ return newSet; }
+    Relation* getRelation(){ return newRelation; }
+};
+
+/*! This class is used in adjusting tuple variable indices for those
+**  constraints that involved in UFCallTerms, after projection.
+*/
+class VisitorProjectOutCleanUp : public Visitor {
+  private:
+    int tvar;
+    int nc_ufc;     // nested UFCallTerm count
+
+  public:
+    VisitorProjectOutCleanUp(int itvar){ tvar = itvar;  nc_ufc = 0;}
+    void preVisitUFCallTerm(iegenlib::UFCallTerm * t){
+        nc_ufc++;
+    }
+    void postVisitUFCallTerm(iegenlib::UFCallTerm * t){
+        nc_ufc--;
+    }
+    void preVisitTupleVarTerm(iegenlib::TupleVarTerm * t){
+        if( nc_ufc && t->tvloc() > tvar){
+            TupleVarTerm newT( t->coefficient() , t->tvloc()-1 );
+            *t = newT;
+        }
+    }
+};
+
+/*! Projects out tuple varrable No. tvar if tvar is not argument to any UFCall
+**  tvar is calculated based on ariety starting from 0.
+**  Consequently, to project out jp from S: tvar = 5
+**     S = {[i,j,k,ip,jp,kp] : ...}
+**
+**  NOTE: if tvar is argument some UFCall, then we cannot project it out
+**        and functions returns NULL.
+**        Ex: if col(k) in constraints exists we cannot project out 'k'
+*/
+Set* Set::projectOut(int tvar)
+{
+    if (isUFCallParam(tvar)){
+      return NULL;
+    }
+    
+    // Geting a map of UFCalls 
+    iegenlib::UFCallMap *ufcmap;
+    ufcmap = this->mapUFCtoSym();
+    // Getting the super affine set of constraints with no UFCallTerms
+    Set* sup_s = this->superAffineSet(ufcmap);
+
+    // Projecting out tvar using ISL library
+    VisitorProjectOut* pv = new VisitorProjectOut(tvar, 0);
+    sup_s->acceptVisitor(pv);
+    delete sup_s;
+    sup_s = pv->getSet();
+
+    // Getting the reverseAffineSubstitution
+    Set* result = sup_s->reverseAffineSubstitution(ufcmap);
+
+    // Adjusting changes in UFCTerms due to projection: _tvN -> _tvN-1
+    VisitorProjectOutCleanUp* cv = new VisitorProjectOutCleanUp(tvar);
+    result->acceptVisitor(cv);
+
+    delete sup_s;
+    delete cv;
+    delete pv;
+   
+    return result;
+}
+
+/*! Projects out tuple varrable No. tvar if tvar is not argument to any UFCall
+**  tvar is calculated based on total ariety (in+out) starting from 0.
+**  Consequently, to project out jp from R: tvar = 5
+**     R = {[i,j,k] -> [ip,jp,kp] : ...}
+**
+**  NOTE: if tvar is argument some UFCall, then we cannot project it out
+**        and functions returns NULL.
+**        Ex: if col(k) in constraints exists we cannot project out 'k'
+*/
+Relation* Relation::projectOut(int tvar)
+{
+    if (isUFCallParam(tvar)){
+      return NULL;
+    }
+    
+    // Geting a map of UFCalls 
+    iegenlib::UFCallMap *ufcmap;
+    ufcmap = this->mapUFCtoSym();
+    // Getting the super affine set of constraints with no UFCallTerms
+    Relation* sup_r = this->superAffineRelation(ufcmap);
+
+    // Projecting out tvar using ISL library
+    VisitorProjectOut* pv = new VisitorProjectOut(tvar, sup_r->inArity());
+    sup_r->acceptVisitor(pv);
+    delete sup_r;
+    sup_r = pv->getRelation();
+
+    // Getting the reverseAffineSubstitution
+    Relation* result = sup_r->reverseAffineSubstitution(ufcmap);
+
+    // Adjusting changes in UFCTerms due to projection: _tvN -> _tvN-1
+    VisitorProjectOutCleanUp* cv = new VisitorProjectOutCleanUp(tvar);
+    result->acceptVisitor(cv);
+
+    delete sup_r;
+    delete cv;
+    delete pv;
+   
+    return result;
+}
+
 
 }//end namespace iegenlib

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -85,12 +85,10 @@ public:
     //! Comparison operator -- lexicographic order
     bool operator<(const Conjunction& other) const;
 
-/*
-	//! Given inarity parameter is adopted.
-	//! If inarity parameter is outside of feasible range for the existing
-	//! existing TupleDecl then throws exception.
+    //! Given inarity parameter is adopted.
+    //! If inarity parameter is outside of feasible range for the existing
+    //! existing TupleDecl then throws exception.
     void setInArity(int inarity);
-*/
     
     //! Given tuple declaration parameter is adopted.
     //! If there are some constants that don't agree then throws exception.
@@ -163,7 +161,6 @@ public:
     int arity() const { return mTupleDecl.size(); }
     //! Get/Set inarity, for use with relations
     int inarity() const { return mInArity; }
-    void setinarity(int in) { mInArity = in; }
     
     //! Returns true if the conjunction has at least one equality or inequality
     //! constraints.  If it contains none then this Conjunction is just
@@ -534,7 +531,8 @@ public:
     */
     Set* reverseAffineSubstitution(UFCallMap* ufcmap);
 
-    //  Projects out tuple varrable No. tvar
+    //! Projects out tuple var No. tvar, if it is not an argument to a UFCall.
+    //! If tvar is an argument to some UFCall, then returns NULL.
     Set* projectOut(int tvar);
 
 private:
@@ -692,8 +690,8 @@ public:
     */
     Relation* reverseAffineSubstitution(UFCallMap* ufcmap);
 
-    //! Projects out tuple varrable No. tvar.
-    //  FIXME: if legal to do so right?  MMS 2/27/16 
+    //! Projects out tuple var No. tvar, if it is not an argument to a UFCall.
+    //! If tvar is an argument to some UFCall, then returns NULL.
     Relation* projectOut(int tvar);
 
 private:

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3635,137 +3635,6 @@ TEST_F(SetRelationTest, isUFCallParam) {
    delete r2;
 }
 
-//*****************************************************************************
-// Testing project_out: project out tuple variable # tvar
-
-TEST_F(SetRelationTest, PROJECT_OUT) {
-
-    iegenlib::setCurrEnv();
-    iegenlib::appendCurrEnv("col",
-        new Set("{[i]:0<=i &&i<n}"), 
-        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
-    iegenlib::appendCurrEnv("idx",
-        new Set("{[i]:0<=i &&i<n}"), 
-        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
-    iegenlib::appendCurrEnv("row",
-        new Set("{[i]:0<=i &&i<n}"), 
-        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
-    iegenlib::appendCurrEnv("diag",
-        new Set("{[i]:0<=i &&i<n}"), 
-        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
-
-    Relation *r1 = new Relation("[n] -> { [i,k,j1,j2] -> [ip,kp,jp1,jp2] :"
-    " i < ip and j1 = jp2 and 0 <= i and i < n and 0 <= ip and ip < n and "
-     "k+1 <= j1 and j1 < row(i+1) and kp+1 <= jp1 and jp1 < row(ip+1) and "
-       "diag(col(k))+1 <= j2 and j2 < row(col(k)+1) and diag(col(kp))+1 <="
-           " jp2 and jp2 < row(col(kp)+1) and row(i) <= k and k < diag(i) "
-           "and row(ip) <= kp and kp < diag(ip) }");
-
-
-    Set *s1 = new Set("[n] -> { [i,j,ip,jp] : i = col(jp) "
-       "and i < ip and 0 <= i and i < n and idx(i) <= j and j < idx(i+1) "
-         "and 0 <= ip and ip < n and idx(ip) <= jp and jp < idx(ip+1) }");
-
-
-    Relation *ex_r1 = new Relation("[ n ] -> { [i, k] -> [ip, kp] : i >= 0"
-         " && col(k) >= 0 && col(kp) >= 0 && diag(i) >= 0 && diag(ip) >= 0"
-      " && diag(col(k)) >= 0 && diag(col(kp)) >= 0 && row(i) >= 0 && row(i"
-   " + 1) >= 0 && row(ip) >= 0 && row(ip + 1) >= 0 && row(col(k) + 1) >= 0"
-     " && row(col(kp) + 1) >= 0 && k - row(i) >= 0 && kp - row(ip) >= 0 &&"
-   " -i + ip - 1 >= 0 && -k + diag(i) - 1 >= 0 && -k + row(i + 1) - 2 >= 0"
-          " && -k + row(col(kp) + 1) - 2 >= 0 && -ip + n - 2 >= 0 && -kp +"
-       " diag(ip) - 1 >= 0 && -kp + row(ip + 1) - 2 >= 0 && n - col(k) - 2"
-      " >= 0 && n - col(k) - 1 >= 0 && n - col(kp) - 2 >= 0 && n - col(kp)"
-        " - 1 >= 0 && n - diag(i) - 1 >= 0 && n - diag(ip) - 1 >= 0 && n -"
-       " diag(col(k)) - 1 >= 0 && n - diag(col(kp)) - 1 >= 0 && n - row(i)"
-      " - 1 >= 0 && n - row(i + 1) - 1 >= 0 && n - row(ip) - 1 >= 0 && n -"
-             " row(ip + 1) - 1 >= 0 && n - row(col(k) + 1) - 1 >= 0 && n -"
-     " row(col(kp) + 1) - 1 >= 0 && -diag(col(k)) + row(col(k) + 1) - 2 >="
-             " 0 && -diag(col(kp)) + row(i + 1) - 2 >= 0 && -diag(col(kp))"
-                                           " + row(col(kp) + 1) - 2 >= 0 }");
-
-    Set *ex_s1 = new Set("[ n ] -> { [i, ip, jp] : i - col(jp) = 0 && i >= 0"
-                    " && idx(i) >= 0 && idx(ip) >= 0 && jp - idx(ip) >= 0"
-  " && -i + ip - 1 >= 0 && -ip + n - 2 >= 0 && -jp + idx(ip + 1) - 1 >= 0"
-                 " && n - idx(i + 1) - 1 >= 0 && n - idx(ip + 1) - 1 >= 0"
-                                     " && -idx(i) + idx(i + 1) - 1 >= 0 }");
-
-
-   // Here, we are going to project out all tuple variables of r1
-   // except for i,ip, and those of them that are argument to 
-   // Uninterpreted Function Symbols (UFS's).
-   // Note that, current project_out function first checks to see
-   // whether the tuple variable that is going to be projected out
-   // is argument to any UFS, if it is, it terminates, and returns NULL.
-   // However, if the tuple variable is not argument to any UFS,
-   // it will project it out, and return new Relation/Set.
-
-   // Temprory relation
-   Relation *r2;
-
-   // (1) Projecting out 'jp2' from r1: notice that we store the immediate
-   // return value of project out in a temporary relation, namely r2, since 
-   // it can be NULL upon failure. Also, project out will not change
-   // the calling object.
-   
-   r2 = r1->projectOut(7);    // 7 == index of 'jp2'
-   if ( r2 ){
-     delete r1;               // removing old r1
-     r1 = r2;
-   }
-
-   // (2) Projecting out 'jp1' from r1
-   
-   r2 = r1->projectOut(6);    // 6 == index of 'jp1'
-   if ( r2 ){
-     delete r1;               // removing old r1
-     r1 = r2;
-   }
-
-   // Note that k and kp are arguments to UFS's and connot be projected out.
-
-   // (3) Projecting out 'j2' from r1
-   
-   r2 = r1->projectOut(3);    // 3 == index of 'j2'
-   if ( r2 ){
-     delete r1;               // removing old r1
-     r1 = r2;
-   }
-
-   // (4) Projecting out 'j1' from r1
-   
-   r2 = r1->projectOut(2);    // 2 == index of 'j1'
-   if ( r2 ){
-     delete r1;               // removing old r1
-     r1 = r2;
-   }
-
-
-   Set *s2;
-   // projectOut has the same behaivor for both Relation and Set
-
-  // Projecting out 'j' from s1
-  s2 = s1->projectOut(1);     // 1 == index of 'j'
-
-  if ( s2 ){
-     delete s1;               // removing old r1    
-     s1 = s2;
-  }
-
-//   std::cout << std::endl << "r2.pr = " << r2->toISLString() << std::endl;
-//   std::cout << std::endl << "s1.pr = " << s1->toISLString() << std::endl;
-
-   EXPECT_EQ( r1->toISLString() , ex_r1->toISLString() );
-   EXPECT_EQ( s1->toISLString() , ex_s1->toISLString() );
-
-   delete r1;
-//   delete r2;      // r1 == r2
-   delete s1;
-//   delete s2;      // s1 == r2
-   delete ex_r1;
-   delete ex_s1;
-}
-
 #pragma mark mapUFCtoSym
 //Testing mapUFCtoSym: get a map of all UFCalls to equ. symbolic constant
 TEST_F(SetRelationTest, mapUFCtoSym) {
@@ -4025,5 +3894,106 @@ TEST_F(SetRelationTest, reverseAffineSubstitution) {
     delete su_s2;
     delete r1;
     delete su_r1;
-
 }
+
+
+#pragma mark projectOut
+// Testing projectOut: project out tuple variable # tvar
+TEST_F(SetRelationTest, projectOut) {
+
+    iegenlib::setCurrEnv();
+    iegenlib::appendCurrEnv("col",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+    iegenlib::appendCurrEnv("idx",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+    iegenlib::appendCurrEnv("row",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+    iegenlib::appendCurrEnv("diag",
+        new Set("{[i]:0<=i &&i<n}"), 
+        new Set("{[j]:0<=j &&j<n}"), true, iegenlib::Monotonic_NONE);
+
+   // Note that, current project_out function first checks to see
+   // whether the tuple variable that is going to be projected out
+   // is argument to any UFS, if it is, it terminates, and returns NULL.
+   // However, if the tuple variable is not argument to any UFS,
+   // it will project it out, and return new Relation/Set.
+   // Additionally, the function adds constraints that are due to domain
+   //  and range info of all UFCall terms in the Set/Relation, for instance:
+   //  if we have: col( x ) + y > 5    then  
+   //                             ldb <= x <= udb and lrb <= col(x) <= urb
+   //              will be added to constraints.
+   //              * ldb = lower domain bound, urb = upper range bound
+
+    Relation *r1 = new Relation("{ [i,k] -> [ip,kp] :"
+       " i < ip and diag(col(i))+1 <= k }"
+                         " union { [i,k] -> [ip,kp] :"
+       " i > ip and i = kp and kp < diag(i) }");
+
+    Relation *ex_r1 = new Relation("{ [i] -> [ip] : i >= 0 && diag(i) >= 0"
+                " && i < n && i < diag(i) && i > ip && diag(i) < n } union "
+             "{ [i] -> [ip] : i >= 0 && col(i) >= 0 && diag(col(i)) >= 0 &&"
+ " i < ip && i < n && col(i) < n && diag(col(i)) < n }");
+
+    Relation *r2; 
+    r2 = r1->projectOut(3);    // 5 == index of 'kp'
+    if ( r2 ){                 // Did we project out 'jp': YES!
+        delete r1;             // removing old r1
+        r1 = r2;
+    }
+
+    r2 = r1->projectOut(0);    // 1 == index of 'i'
+    if ( r2 ){                 // Did we project out 'k': NO!
+        delete r1;             // The reason is that k is argumnet to col().
+        r1 = r2;               // We don't project out variables
+    }                          // that are argument to an UFCall.
+
+    r2 = r1->projectOut(1);    // 2 == index of 'k'
+    if ( r2 ){                 // did we project out 'j': YES!
+        delete r1;             // removing old r1
+        r1 = r2;
+    }
+
+
+//   std::cout << std::endl << "r1 = " << r1->toISLString() << std::endl;
+
+   EXPECT_EQ( ex_r1->toISLString() , r1->toISLString() );
+
+    Set *s1 = new Set("{ [i,j,ip,jp] : i = col(jp)+1 and 0 <= i and i < n"
+                                     " and idx(i) <= j and j < idx(i+1) }");
+
+    Set *ex_s1 = new Set("{ [i, jp] : i = col(jp)+1 and i >= 0 and i+1 >= 0"
+           " and jp >= 0 and idx(i) >= 0 and idx(i+1) >= 0 and col(jp) >= 0"
+          " and i < n and i < n-1 and jp < n and col(jp) < n and idx(i) < n"
+                               " and idx(i+1) < n and idx(i) < idx(i + 1) }");
+
+   Set *s2;
+   // projectOut has the same behaivor for both Relation and Set
+
+  // Projecting out 'j' from s1
+  s2 = s1->projectOut(1);     // 1 == index of 'j'
+
+  if ( s2 ){
+     delete s1;               // removing old s1    
+     s1 = s2;
+  }
+  // Projecting out 'ip' from s1
+  s2 = s1->projectOut(1);     // 1 == index of 'ip' (in new results)
+
+  if ( s2 ){
+     delete s1;               // removing old s1    
+     s1 = s2;
+  }
+//   std::cout << std::endl << "s1 = " << s1->toISLString() << std::endl;
+
+   EXPECT_EQ( ex_s1->toISLString() , s1->toISLString() );
+
+   delete r1;
+   delete s1;
+   delete ex_r1;
+   delete ex_s1;
+}
+
+


### PR DESCRIPTION
The old project out is removed. The new project out works with functions that follow visitor design.

To project out tuple var No. tv:
(1) First, we check if tv is not a UFC argument
(2) Then, we get superAffineSet/Relation
(3) Next, we use isl to project out tv from superAffineSet/Relation
(4) Now, we convert results back to non-affine using reverseAffine Substitution.
(5) Finally, we do a clean up, to adjust tuple variable IDs that were arguments of UFCalls.
                  Therefore those tuple variables were not affected by project out.
