### PR TITLE
Added isl_str_manipulation functions

### DIFF
--- a/src/set_relation/isl_str_manipulation.cc
+++ b/src/set_relation/isl_str_manipulation.cc
@@ -1,0 +1,291 @@
+/*!
+ * \file isl_str_manipulation.h
+ *
+ * \Implementations of isl string manipulator functions
+ *
+ * \date Started: 2016-03-11
+ *
+ * \authors Michelle Strout, Mahdi Soltan Mohammadi
+ *
+ * Copyright (c) 2016, University of Arizona <br>
+ * All rights reserved. 
+ * See ../../COPYING for details. <br>
+ */
+
+#include "isl_str_manipulation.h"
+
+namespace iegenlib{
+
+
+//****** ISL tuple correction functions
+
+/*! This function extracts tuple variables from a Tuple Declaration string.
+**  Tuple Declaration can be either of Relation or Set form
+**  Input:  "[i1,col_tv3_] -> [i3,i4]" or
+**          "[i1,col_tv3_,i3,i4]"  
+**  Output: (pointer to)
+**          {"i1", "col_tv3_", "i3", "i4"}
+*/
+std::string* tupVarsExtract(std::string tupDecl, int inArity, int outArity){
+
+    int st=0, end=0, idxSt = 0;
+    int nparts=1;
+    int arity = inArity + outArity;
+    std::string* tupVars = new std::string[arity];
+
+    if( outArity != 0 ){
+      nparts = 2;
+      arity = inArity;
+    }
+    for(int p=0 ; p < nparts ; p++){
+        st = tupDecl.find_first_of('[', st);
+        end = tupDecl.find_first_of(']', st);
+        std::string str = tupDecl.substr(st+1,end-st-1);
+
+        int tst = 0,tend = 0 ;
+        for(int i = 0 ; i < arity ; i++ ){
+
+            tend = str.find_first_of(',', tst);
+            tupVars[idxSt + i] = str.substr(tst,tend-tst);
+            tst = tend + 1;
+        }
+
+        arity = outArity;
+        idxSt = inArity;
+        st = end + 1;
+    }
+
+    return tupVars;
+}
+/*! This function checks to see whether two Tuple Variables are equal
+**  regardless of spacing before and after their names:
+**  "  ip " == "ip"
+*/
+#define unsigned int uint
+bool tvEqCheck(std::string tv1, std::string tv2){
+    int nonSpSt = 0, nonSpFi = tv1.length()-1;
+    for( uint i = 0; tv1[nonSpSt] == ' ' && i < tv1.length(); i++, nonSpSt++ );
+    for( uint i = 0; tv1[nonSpFi] == ' ' && i < tv1.length(); i++, nonSpFi-- );
+    tv1 = tv1.substr(nonSpSt,nonSpFi-nonSpSt+1);
+
+    nonSpSt = 0;
+    nonSpFi = tv2.length()-1;
+    for( uint i = 0; tv2[nonSpSt] == ' ' && i < tv2.length(); i++, nonSpSt++ );
+    for( uint i = 0; tv2[nonSpFi] == ' ' && i < tv2.length(); i++, nonSpFi-- );
+    tv2 = tv2.substr(nonSpSt,nonSpFi-nonSpSt+1);
+
+    if ( tv1 == tv2 ){
+        return true;
+    }
+
+    return false;
+}
+/*! This function constructs equality constraints between Tuple Varialbes
+**  that are replaced eachother by ISL. To do this, it takes in two
+**  Tuple declaration, extracts their Tuple Variables, then creates
+**  equalities for those that are replaced:
+**      origTupDecl: [i1, i2] -> [1, i4]
+**      islTupDecl : [col_tv1_, i2] -> [1, i2]
+**      output:      (i1) - (col_tv1_) = 0 and (i4) - (i2) = 0
+**  Note: noFirstAnd determines whether we should put "and" at the beginning of
+**  the output string, which depends on original constraints being empty or not. 
+*/
+std::string missingEqs(std::string origTupDecl, std::string islTupDecl,
+                              int inArity, int outArity, bool noFirstAnd){
+    std::string eqs("");
+    int arity = inArity + outArity;
+    bool firstEq = true;
+ 
+    std::string* origTupVars = tupVarsExtract(origTupDecl, inArity, outArity);
+    std::string* islTupVars = tupVarsExtract(islTupDecl, inArity, outArity);
+
+    for(int i = 0 ; i < arity ; i++){
+        if( ! tvEqCheck(origTupVars[i] , islTupVars[i]) ){
+            if(noFirstAnd && firstEq){
+                eqs +=  " (" + origTupVars[i] +
+                        ") - (" + islTupVars[i] + ") = 0";
+                firstEq = false;
+            } else {
+                eqs +=  " and (" + origTupVars[i] +
+                        ") - (" + islTupVars[i] + ") = 0";
+            }
+        
+        }
+    }
+
+    delete[] origTupVars;
+    delete[] islTupVars;
+
+    return eqs;
+}
+/*! This function takes in a Set or Relation string and returns different 
+**  parts of it in a srParts structure.
+*/
+srParts* getPartsFromStr(std::string str){
+    srParts* parts = new srParts();
+    int l1,l2,l3;
+
+    l1 = str.find_first_of('{', 0);
+    l2 = str.find_first_of(':', l1);
+    if( l2 < 0 ){
+        parts->symVars =     str.substr( 0 , l1-0 );
+        l3 = str.find_first_of('}', l1);
+        parts->tupDecl =     str.substr( l1+1 , l3-(l1+1)-1 );
+        parts->constraints = "";
+        return parts;
+    }
+    l3 = str.find_first_of('}', l2);
+
+    parts->symVars =     str.substr( 0 , l1-0 );
+    parts->tupDecl =     str.substr( l1+1 , l2-(l1+1) );
+    parts->constraints = str.substr( l2+1 , l3-(l2+1) );
+
+    return parts;
+}
+/*! The main function that restores uninted changes ISL library apply to
+**  Tuple Declaration because of the equality constraints. ISL library replaces
+**  tuple variables with their equal expression if one exists in the constraints:
+**    input to isl   : [n] -> { [i] : i = n and i < 10 }
+**    output from isl: { [n] : n < 10 }
+**  This function replaces Tuple Declaration from ISL string with original one,
+**  and creates missing equalities and puts them back into constraints.
+*/
+std::string revertISLTupDeclToOrig(std::string origStr, std::string islStr,
+                              int inArity, int outArity){
+    std::string correctedStr, eqsStr;
+    bool noFirstAnd = false;
+    
+    srParts* origParts = getPartsFromStr(origStr);
+    srParts* islParts = getPartsFromStr(islStr);
+
+    if( islParts->constraints.length() == 0 ){
+        noFirstAnd = true;
+    }
+    eqsStr = missingEqs( origParts->tupDecl , islParts->tupDecl ,
+                                inArity, outArity, noFirstAnd );
+    
+    if( islParts->constraints.length() == 0 && eqsStr.length() == 0){
+        correctedStr = islParts->symVars + islParts->sC +
+                       origParts->tupDecl + islParts->eC;
+    } else {
+        correctedStr = islParts->symVars + islParts->sC +
+                       origParts->tupDecl + islParts->sepC + 
+                       islParts->constraints + eqsStr +islParts->eC;
+    }
+    delete origParts;
+    delete islParts;
+
+    return correctedStr;
+}
+/*! This function takes in a Set or Relation string and removes tuple variable
+**  located in poTv position from Tuple Declaration of the string.
+**     str         : [n] -> { [i1,i2,i3] : ... }
+**     poTv        : 1
+**     correctedStr: [n] -> { [i1,i3] : ... }
+*/
+std::string projectOutStrCorrection(std::string str, int poTv,
+                                    int inArity, int outArity){
+    std::string correctedStr, newTupDecl;
+    int arity = inArity + outArity;
+    
+    srParts* parts = getPartsFromStr(str);
+    
+    std::string* origTupVars = tupVarsExtract(parts->tupDecl,
+                                              inArity, outArity);
+    newTupDecl = "[";
+    for (int i = 0 ; i < arity ; i++){
+        if( i == inArity && outArity != 0){
+            newTupDecl += "] -> [";
+        }
+        if( i != poTv ){
+            newTupDecl += origTupVars[i];
+            if( i != arity-1 && i != inArity-1 && 
+                !( ((i == arity-2)&&(poTv == arity-1)) ||
+                   ((i == inArity-2)&&(poTv == inArity-1)) )
+              ){
+                newTupDecl += ", ";
+            }
+        }
+    }
+    newTupDecl += "] ";
+  
+    if (parts->constraints.length() == 0 ){
+        correctedStr = parts->symVars + parts->sC + newTupDecl + parts->eC; 
+    } else{
+        correctedStr = parts->symVars + parts->sC + newTupDecl +
+                       parts->sepC + parts->constraints + parts->eC;
+    }
+
+    delete parts;
+    delete[] origTupVars;
+
+    return correctedStr;
+}
+//****** ISL tuple correction End
+
+//! This function takes a Set string and returns equivalent isl_set*
+isl_set* islStringToSet( std::string relstr , isl_ctx *ctx )
+{
+  // load Relation r into ISL map
+  isl_set* iset = isl_set_read_from_str(ctx, relstr.c_str());
+
+  return iset;
+}
+
+/*! This function takes an isl_set* and returns equivalent Set string
+** The function takes ownership of input argument 'iset'
+*/
+std::string islSetToString ( isl_set* iset , isl_ctx *ctx ) {
+  // Get an isl printer and associate to an isl context
+  isl_printer * ip = isl_printer_to_str(ctx);
+
+  // get string back from ISL map
+  isl_printer_set_output_format(ip, ISL_FORMAT_ISL);
+  isl_printer_print_set(ip, iset);
+  char *i_str = isl_printer_get_str(ip);
+  std::string stringFromISL (i_str); 
+  
+  // clean-up
+  isl_printer_flush(ip);
+  isl_printer_free(ip);
+  isl_set_free(iset);
+  iset= NULL;
+  free(i_str);
+
+  return stringFromISL;
+}
+
+//! This function takes a Relation string and returns pointer to equ. isl_map
+isl_map* islStringToMap( std::string relstr , isl_ctx *ctx )
+{
+  // load Relation r into ISL map
+  isl_map* imap = isl_map_read_from_str(ctx, relstr.c_str());
+
+  return imap;
+}
+
+/*! This function takes an isl_map* and returns pointer to equ. Relation string
+** The function takes ownership of input argument 'imap'
+*/
+std::string islMapToString ( isl_map* imap , isl_ctx *ctx )
+{
+  // Get an isl printer and associate to an isl context
+  isl_printer * ip = isl_printer_to_str(ctx);
+
+  // get string back from ISL map
+  isl_printer_set_output_format(ip , ISL_FORMAT_ISL);
+  isl_printer_print_map(ip ,imap);
+  char *i_str = isl_printer_get_str(ip);
+  std::string stringFromISL (i_str); 
+  
+  // clean-up
+  isl_printer_flush(ip);
+  isl_printer_free(ip);
+  isl_map_free(imap);
+  imap= NULL;
+  free(i_str);
+
+  return stringFromISL;
+}
+
+}// iegenlib namespace

--- a/src/set_relation/isl_str_manipulation.h
+++ b/src/set_relation/isl_str_manipulation.h
@@ -1,0 +1,119 @@
+/*!
+ * \file isl_str_manipulation.h
+ *
+ * \brief Interface of isl string manipulator functions
+ *
+ * \date Started: 2016-03-11
+ *
+ * \authors Michelle Strout, Mahdi Soltan Mohammadi
+ *
+ * Copyright (c) 2016, University of Arizona <br>
+ * All rights reserved. 
+ * See ../../COPYING for details. <br>
+ */
+ 
+#ifndef ISL_STR_MANIPULATION_H_
+#define ISL_STR_MANIPULATION_H_
+
+#include<iostream>
+#include<string>
+
+#include <isl/set.h>   // ISL Sets
+#include <isl/map.h>   // ISL Relations
+
+namespace iegenlib{
+
+
+//****** ISL tuple correction functions
+
+/*! This function extracts tuple variables from a Tuple Declaration string.
+**  Tuple Declaration can be either of Relation or Set form
+**  Input:  "[i1,col_tv3_] -> [i3,i4]" or
+**          "[i1,col_tv3_,i3,i4]"  
+**  Output: (pointer to)
+**          {"i1", "col_tv3_", "i3", "i4"}
+*/
+std::string* tupVarsExtract(std::string tupDecl, int inArity, int outArity);
+
+/*! This function checks to see whether two Tuple Variables are equal
+**  regardless of spacing before and after their names:
+**  "  ip " == "ip"
+*/
+bool tvEqCheck(std::string tv1, std::string tv2);
+
+/*! This function constructs equality constraints between Tuple Varialbes
+**  that are replaced eachother by ISL. To do this, it takes in two
+**  Tuple declaration, extracts their Tuple Variables, then creates
+**  equalities for those that are replaced:
+**      origTupDecl: [i1, i2] -> [1, i4]
+**      islTupDecl : [col_tv1_, i2] -> [1, i2]
+**      output:      (i1) - (col_tv1_) = 0 and (i4) - (i2) = 0
+**  Note: noFirstAnd determines whether we should put "and" at the beginning of
+**  the output string, which depends on original constraints being empty or not. 
+*/
+std::string missingEqs(std::string origTupDecl, std::string islTupDecl,
+                              int inArity, int outArity=0);
+
+//! An Structure to store different parts of a Set or Relation string
+typedef struct srParts{
+
+    srParts(){
+        sC = '{';
+        sepC = ':';
+        eC = '}';
+    }
+
+    std::string symVars;     // Symbolic constants 
+    std::string sC;          // Starting character = '{'
+    std::string tupDecl;     // Tuplel declaration 
+    std::string sepC;        // Separating character = ':'
+    std::string constraints; // Constraints
+    std::string eC;          // Ending character = '}'
+}srParts;
+
+/*! This function takes in a Set or Relation string and returns different 
+**  parts of it in a srParts structure.
+*/
+srParts* getPartsFromStr(std::string str);
+
+/*! The main function that restores uninted changes ISL library apply to
+**  Tuple Declaration because of the equality constraints. ISL library replaces
+**  tuple variables with their equal expression if one exists in the constraints:
+**    input to isl   : [n] -> { [i] : i = n and i < 10 }
+**    output from isl: { [n] : n < 10 }
+**  This function replaces Tuple Declaration from ISL string with original one,
+**  and creates missing equalities and puts them back into constraints.
+*/
+std::string revertISLTupDeclToOrig(std::string origStr, std::string islStr,
+                              int inArity, int outArity);
+
+/*! This function takes in a Set or Relation string and removes tuple variable
+**  located in poTv position from Tuple Declaration of the string.
+**     str         : [n] -> { [i1,i2,i3] : ... }
+**     poTv        : 1
+**     correctedStr: [n] -> { [i1,i3] : ... }
+*/
+std::string projectOutStrCorrection(std::string str, int poTv,
+                                    int inArity, int outArity);
+//****** ISL tuple correction End
+
+//! This function takes a Set string and returns equivalent isl_set*
+isl_set* islStringToSet( std::string relstr , isl_ctx *ctx );
+
+/*! This function takes an isl_set* and returns equivalent Set string
+** The function takes ownership of input argument 'iset'
+*/
+std::string islSetToString ( isl_set* iset , isl_ctx *ctx );
+
+//! This function takes a Relation string and returns pointer to equ. isl_map
+isl_map* islStringToMap( std::string relstr , isl_ctx *ctx );
+
+/*! This function takes an isl_map* and returns pointer to equ. Relation string
+** The function takes ownership of input argument 'imap'
+*/
+std::string islMapToString ( isl_map* imap , isl_ctx *ctx );
+
+
+}// iegenlib namespace
+
+#endif

--- a/src/set_relation/isl_str_manipulation_test.cc
+++ b/src/set_relation/isl_str_manipulation_test.cc
@@ -27,11 +27,13 @@ using namespace iegenlib;
 TEST(revertISLTupDeclToOrigTest, revertISLTupDeclToOrig) {
 
     std::string orig(" [tstep, theta_0__tv1_, col_tv2_]->{[ i1, i2]->"
-                     "[ 0, i4, i5 ,  i6] : i1 = col_i_ and i4 = tstep"
+                     "[ 0, i4, i5 , i6] : i1 = col_i_ and i4 = tstep"
                                       " and i6 = theta_0__tv1_ + 1}");
-    std::string islStr(" {[col_i_ , i2] -> [0 , tstep, i5, theta_0__tv1_ + 1] }");
-    string exp(" {[ i1, i2]->[ 0, i4, i5 ,  i6] : ( i1) - (col_i_ ) = 0 and"
-              " ( i4) - ( tstep) = 0 and (  i6) - ( theta_0__tv1_ + 1) = 0}");
+    std::string islStr(" [tstep, theta_0__tv1_, col_tv2_] -> "
+           "{[col_i_ , i2] -> [0 , tstep, i5, theta_0__tv1_ + 1] }");
+    string exp(" [tstep, theta_0__tv1_, col_tv2_] ->"
+               " {[ i1, i2]->[ 0, i4, i5 , i6] : i1 = col_i_ and"
+                        " i4 = tstep and i6 = theta_0__tv1_ + 1}");
     int inArity = 2, outArity = 4;
     string corrected;
 
@@ -40,11 +42,12 @@ TEST(revertISLTupDeclToOrigTest, revertISLTupDeclToOrig) {
     //cout<<endl<<corrected<<endl<<endl; 
     EXPECT_EQ( exp , corrected );
 
-    std::string s_orig(" {[ i1, i2, i3, i4] : i1 = col_i_ and i4 = tstep and i4 = theta_0__tv1_ + 1 and i1 >= 0 and i2 <= 10}");
+    std::string s_orig(" {[ i1, i2 , i3, i4] : i1 = col_i_ and"
+       " i4 = tstep and i4 = theta_0__tv1_ + 1 and i1 >= 0 and i2 <= 10}");
     std::string s_islStr(" {[col_i_ , i2, tstep, theta_0__tv1_ + 1] : "
                                                           " i2 <= 10 }");
-    string s_exp(" {[ i1, i2, i3, i4] :  i2 <= 10  and ( i1) - (col_i_ ) = 0"
-            " and ( i3) - ( tstep) = 0 and ( i4) - ( theta_0__tv1_ + 1) = 0}");
+    string s_exp(" {[ i1, i2 , i3, i4] :  i2 <= 10  and"
+                 " i1 = col_i_ and i3 = tstep and i4 = theta_0__tv1_ + 1}");
 
     inArity = 4;outArity = 0;
     corrected = revertISLTupDeclToOrig(s_orig, s_islStr, inArity, outArity);
@@ -58,7 +61,7 @@ TEST(revertISLTupDeclToOrigTest, revertISLTupDeclToOrig) {
 TEST(revertISLTupDeclToOrigTest, projectOutStrCorrection) {
 
     string islStr("{[col_i_ , i2] -> [0 , tstep, i5, theta_0__tv1_ + 1] }");
-    string exp(   "{[col_i_ ,  i2] -> [ tstep,  i5,  theta_0__tv1_ + 1] }");
+    string exp(   "{[col_i_, i2] -> [tstep, i5, theta_0__tv1_ + 1] }");
     int inArity = 2, outArity = 4;
     string corrected;
 
@@ -66,7 +69,7 @@ TEST(revertISLTupDeclToOrigTest, projectOutStrCorrection) {
 
     EXPECT_EQ( exp , corrected );
 
-    exp = "{[col_i_ ,  i2] -> [0 ,  tstep] }";
+    exp = "{[col_i_, i2] -> [0, tstep] }";
     inArity = 2; outArity = 3;
 
     corrected = projectOutStrCorrection(islStr, 4, inArity, outArity);
@@ -76,7 +79,7 @@ TEST(revertISLTupDeclToOrigTest, projectOutStrCorrection) {
 
     std::string s_islStr(" {[col_i_ , i2, tstep, theta_0__tv1_ + 1] : "
                                                 "col_i_ >= 0 and i2 <= 10}");
-    string s_exp(        " {[col_i_ ,  i2,  tstep] : "
+    string s_exp(        " {[col_i_, i2, tstep] : "
                                                 "col_i_ >= 0 and i2 <= 10}");
 
     inArity = 4;outArity = 0;

--- a/src/set_relation/isl_str_manipulation_test.cc
+++ b/src/set_relation/isl_str_manipulation_test.cc
@@ -1,0 +1,87 @@
+/*!
+ * \file UFCallMap_test.cc
+ *
+ * \brief Test for the UFCallMap class.
+ *
+ * \date Started: 2016-03-14
+ *
+ * \authors Michelle Strout, Mahdi Soltan Mohammadi
+ *
+ * Copyright (c) 2015-2016, University of Arizona <br>
+ * All rights reserved. 
+ * See ../../COPYING for details. <br>
+ */
+
+#include "isl_str_manipulation.h"
+
+#include <gtest/gtest.h>
+#include <utility>
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+using namespace iegenlib;
+
+#pragma mark revertISLTupDeclToOrig
+// Test the revertISLTupDeclToOrig functionality
+TEST(revertISLTupDeclToOrigTest, revertISLTupDeclToOrig) {
+
+    std::string orig(" [tstep, theta_0__tv1_, col_tv2_]->{[ i1, i2]->"
+                     "[ 0, i4, i5 ,  i6] : i1 = col_i_ and i4 = tstep"
+                                      " and i6 = theta_0__tv1_ + 1}");
+    std::string islStr(" {[col_i_ , i2] -> [0 , tstep, i5, theta_0__tv1_ + 1] }");
+    string exp(" {[ i1, i2]->[ 0, i4, i5 ,  i6] : ( i1) - (col_i_ ) = 0 and"
+              " ( i4) - ( tstep) = 0 and (  i6) - ( theta_0__tv1_ + 1) = 0}");
+    int inArity = 2, outArity = 4;
+    string corrected;
+
+    corrected = revertISLTupDeclToOrig(orig, islStr, inArity, outArity);
+
+    //cout<<endl<<corrected<<endl<<endl; 
+    EXPECT_EQ( exp , corrected );
+
+    std::string s_orig(" {[ i1, i2, i3, i4] : i1 = col_i_ and i4 = tstep and i4 = theta_0__tv1_ + 1 and i1 >= 0 and i2 <= 10}");
+    std::string s_islStr(" {[col_i_ , i2, tstep, theta_0__tv1_ + 1] : "
+                                                          " i2 <= 10 }");
+    string s_exp(" {[ i1, i2, i3, i4] :  i2 <= 10  and ( i1) - (col_i_ ) = 0"
+            " and ( i3) - ( tstep) = 0 and ( i4) - ( theta_0__tv1_ + 1) = 0}");
+
+    inArity = 4;outArity = 0;
+    corrected = revertISLTupDeclToOrig(s_orig, s_islStr, inArity, outArity);
+
+    //cout<<endl<<corrected<<endl<<endl; 
+    EXPECT_EQ( s_exp , corrected );
+}
+
+#pragma mark projectOutStrCorrection
+// Test the projectOutStrCorrection functionality
+TEST(revertISLTupDeclToOrigTest, projectOutStrCorrection) {
+
+    string islStr("{[col_i_ , i2] -> [0 , tstep, i5, theta_0__tv1_ + 1] }");
+    string exp(   "{[col_i_ ,  i2] -> [ tstep,  i5,  theta_0__tv1_ + 1] }");
+    int inArity = 2, outArity = 4;
+    string corrected;
+
+    corrected = projectOutStrCorrection(islStr, 2, inArity, outArity);
+
+    EXPECT_EQ( exp , corrected );
+
+    exp = "{[col_i_ ,  i2] -> [0 ,  tstep] }";
+    inArity = 2; outArity = 3;
+
+    corrected = projectOutStrCorrection(islStr, 4, inArity, outArity);
+
+    EXPECT_EQ( exp , corrected );
+
+
+    std::string s_islStr(" {[col_i_ , i2, tstep, theta_0__tv1_ + 1] : "
+                                                "col_i_ >= 0 and i2 <= 10}");
+    string s_exp(        " {[col_i_ ,  i2,  tstep] : "
+                                                "col_i_ >= 0 and i2 <= 10}");
+
+    inArity = 4;outArity = 0;
+    corrected = projectOutStrCorrection(s_islStr, 3, inArity, outArity);
+
+    //cout<<endl<<corrected<<endl<<endl; 
+    EXPECT_EQ( s_exp , corrected );
+}

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -20,111 +20,66 @@
 #include <map>
 #include <assert.h>
 
+//#include "isl_str_manipulation.h"
+
 namespace iegenlib{
 
 /************************ ISL helper routines ****************************/
 
-//! This function takes a Set string and returns equivalent isl_set*
-isl_set* islStringToSet( std::string relstr , isl_ctx *ctx )
-{
-  // load Relation r into ISL map
-  isl_set* iset = isl_set_read_from_str(ctx, relstr.c_str());
+//! Runs an Affine Set through ISL and returns the resulting normalized set
+Set* passSetThruISL(Set* s){
 
-  return iset;
-}
-
-/*! This function takes an isl_set* and returns equivalent Set string
-** The function takes ownership of input argument 'iset'
-*/
-std::string islSetToString ( isl_set* iset , isl_ctx *ctx ) {
-  // Get an isl printer and associate to an isl context
-  isl_printer * ip = isl_printer_to_str(ctx);
-
-  // get string back from ISL map
-  isl_printer_set_output_format(ip, ISL_FORMAT_ISL);
-  isl_printer_print_set(ip, iset);
-  char *i_str = isl_printer_get_str(ip);
-  std::string stringFromISL (i_str); 
-  
-  // clean-up
-  isl_printer_flush(ip);
-  isl_printer_free(ip);
-  isl_set_free(iset);
-  iset= NULL;
-  free(i_str);
-
-  return stringFromISL;
-}
-
-//! This function takes a Relation string and returns pointer to equ. isl_map
-isl_map* islStringToMap( std::string relstr , isl_ctx *ctx )
-{
-  // load Relation r into ISL map
-  isl_map* imap = isl_map_read_from_str(ctx, relstr.c_str());
-
-  return imap;
-}
-
-/*! This function takes an isl_map* and returns pointer to equ. Relation string
-** The function takes ownership of input argument 'imap'
-*/
-std::string islMapToString ( isl_map* imap , isl_ctx *ctx )
-{
-  // Get an isl printer and associate to an isl context
-  isl_printer * ip = isl_printer_to_str(ctx);
-
-  // get string back from ISL map
-  isl_printer_set_output_format(ip , ISL_FORMAT_ISL);
-  isl_printer_print_map(ip ,imap);
-  char *i_str = isl_printer_get_str(ip);
-  std::string stringFromISL (i_str); 
-  
-  // clean-up
-  isl_printer_flush(ip);
-  isl_printer_free(ip);
-  isl_map_free(imap);
-  imap= NULL;
-  free(i_str);
-
-  return stringFromISL;
-}
-
-//! runs the Set through ISL and returns the resulting string
-string passSetThruISL(string rstr) {
+  string sstr = s->toISLString();
 
   isl_ctx *ctx = isl_ctx_alloc();
-
-  string result =  islSetToString ( islStringToSet(rstr,ctx), ctx );
-
+  string islStr =  islSetToString ( islStringToSet(sstr,ctx), ctx );
   isl_ctx_free(ctx);
+
+  // We need to revert changes that isl applies to Tuple Declaration
+  int inArity = s->arity(), outArity = 0;
+  string corrected = revertISLTupDeclToOrig( sstr, islStr, inArity, outArity);
+  Set* result = new Set(corrected);
 
   return result;
 }
 
-//! Runs a Relation string through ISL and returns the resulting string
-string passRelationThruISL(string rstr) {
+//! Runs an Affine Relation through ISL and returns the normalized result
+Relation* passRelationThruISL(Relation* r){
+
+  string rstr = r->toISLString();
 
   isl_ctx *ctx = isl_ctx_alloc();
-
-  string result =  islMapToString ( islStringToMap(rstr,ctx), ctx );
-
+  string islStr =  islMapToString ( islStringToMap(rstr,ctx), ctx );
   isl_ctx_free(ctx);
+
+  // We need to revert changes that isl applies to Tuple Declaration
+  int inArity = r->inArity(), outArity = r->outArity();
+  string corrected = revertISLTupDeclToOrig( rstr, islStr, inArity, outArity);
+  Relation* result = new Relation( corrected);
+
+//    std::cout<<std::endl<<"r = "<<rstr<<std::endl<<"i = "<<islStr<<std::endl<<std::endl;
+//    std::cout<<std::endl<<"c = "<<corrected<<std::endl<<std::endl;
 
   return result;
 }
 
 // This function can be used for Projecting out a tuple variable
 // from an affine set string using isl library
-string islSetProjectOut(string rstr, unsigned pos) {
+Set* islSetProjectOut(Set* s, unsigned pos) {
+
+  string sstr = s->toISLString();
 
   isl_ctx *ctx = isl_ctx_alloc();
-
-  string result = islSetToString ( 
-               isl_set_project_out(islStringToSet(rstr,ctx), 
+  string islStr = islSetToString ( 
+               isl_set_project_out(islStringToSet(sstr,ctx), 
                                    isl_dim_out, pos, 1), ctx 
                );
-
   isl_ctx_free(ctx);
+
+  // We need to revert the changes that isl applies to Tuple Declaration
+  string projected = projectOutStrCorrection(sstr, pos, s->arity(), 0);
+  string corrected = revertISLTupDeclToOrig( projected, islStr, s->arity(), 0);
+  Set* result = new Set( corrected);
 
   return result;
 }
@@ -132,8 +87,7 @@ string islSetProjectOut(string rstr, unsigned pos) {
 #pragma mark -
 /****************************** Conjunction *********************************/
 
-Conjunction::Conjunction(int arity) : mTupleDecl(arity), mInArity(0)
-{
+Conjunction::Conjunction(int arity) : mTupleDecl(arity), mInArity(0){
 }
 
 Conjunction::Conjunction(TupleDecl tdecl) : mTupleDecl(tdecl), mInArity(0) {
@@ -1905,8 +1859,7 @@ void Set::normalize() {
     Set* superset_copy = superAffineSet(uf_call_map);
 
     // Send affine super set to ISL and let it normalize it.
-    Set* superset_normalized 
-        = new Set(passSetThruISL(superset_copy->toISLString()));
+    Set* superset_normalized = passSetThruISL(superset_copy);
  
      // Reverse the substitution of vars for uf calls.
     Set* normalized_copy 
@@ -2242,8 +2195,7 @@ void Relation::normalize() {
     Relation* superset_copy = superAffineRelation(uf_call_map);
 
     // Send affine super set to ISL and let it normalize it.
-    Relation* superset_normalized 
-        = new Relation(passRelationThruISL(superset_copy->toISLString()));
+    Relation* superset_normalized = passRelationThruISL(superset_copy);
  std::cout << "superset_normalized = " << superset_normalized->toString() << std::endl;
      // Reverse the substitution of vars for uf calls.
     Relation* normalized_copy 
@@ -3352,16 +3304,16 @@ class VisitorProjectOut : public Visitor {
         targetConst->setInArity(0);
         Set * cs = new Set(targetConst->arity() );
         cs->addConjunction(targetConst);
-
+/*
         // Use ISL to project out tuple variable.
         // (a) get string from conjunction
         std::string conjString = cs->toISLString();
-
+*/
         // (b) send through ISL to project out desired tuple variable
-        string fromISL = islSetProjectOut(conjString, tvar);
+//        string fromISL = islSetProjectOut(conjString, tvar);
 
         // (c) convert back to a Conjunction
-        Set* islSet = new Set(fromISL);
+        Set* islSet = islSetProjectOut(cs, tvar);// new Set(fromISL);
         Conjunction* crc = new Conjunction ( *(islSet->mConjunctions.front()) );
         crc->setInArity( inArity );
 

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -36,6 +36,8 @@ class Visitor;
 #include <iostream>
 #include <map>
 
+#include "isl_str_manipulation.h"
+
 #include <isl/set.h>   // ISL Sets
 #include <isl/map.h>   // ISL Relations
 

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3927,24 +3927,21 @@ TEST_F(SetRelationTest, projectOut) {
    //              will be added to constraints.
    //              * ldb = lower domain bound, urb = upper range bound
 
-    Relation *r1 = new Relation("{ [i,k] -> [ip,kp] :"
-       " i < ip and diag(col(i))+1 <= k }"
-                         " union { [i,k] -> [ip,kp] :"
-       " i > ip and i = kp and kp < diag(i) }");
+    Relation *r1 = new Relation("{ [i,k] -> [ip,kp] :  i = kp and col(i) < n"
+                                     " and i < ip and diag(col(i))+1 <= k }");
 
-    Relation *ex_r1 = new Relation("{ [i] -> [ip] : i >= 0 && diag(i) >= 0"
-                " && i < n && i < diag(i) && i > ip && diag(i) < n } union "
-             "{ [i] -> [ip] : i >= 0 && col(i) >= 0 && diag(col(i)) >= 0 &&"
- " i < ip && i < n && col(i) < n && diag(col(i)) < n }");
+    Relation *ex_r1 = new Relation("{ [i] -> [ip] : i < ip  and "
+     "0 <= i and i < n and col(i) >= 0 and diag(col(i)) >= 0 and"
+                             " col(i) < n and diag(col(i)) < n }");
 
     Relation *r2; 
-    r2 = r1->projectOut(3);    // 5 == index of 'kp'
+    r2 = r1->projectOut(3);    // 3 == index of 'kp'
     if ( r2 ){                 // Did we project out 'jp': YES!
         delete r1;             // removing old r1
         r1 = r2;
     }
 
-    r2 = r1->projectOut(0);    // 1 == index of 'i'
+    r2 = r1->projectOut(0);    // 0 == index of 'i'
     if ( r2 ){                 // Did we project out 'k': NO!
         delete r1;             // The reason is that k is argumnet to col().
         r1 = r2;               // We don't project out variables
@@ -3955,19 +3952,18 @@ TEST_F(SetRelationTest, projectOut) {
         delete r1;             // removing old r1
         r1 = r2;
     }
-
-
 //   std::cout << std::endl << "r1 = " << r1->toISLString() << std::endl;
 
    EXPECT_EQ( ex_r1->toISLString() , r1->toISLString() );
 
+
+
     Set *s1 = new Set("{ [i,j,ip,jp] : i = col(jp)+1 and 0 <= i and i < n"
                                      " and idx(i) <= j and j < idx(i+1) }");
 
-    Set *ex_s1 = new Set("{ [i, jp] : i = col(jp)+1 and i >= 0 and i+1 >= 0"
-           " and jp >= 0 and idx(i) >= 0 and idx(i+1) >= 0 and col(jp) >= 0"
-          " and i < n and i < n-1 and jp < n and col(jp) < n and idx(i) < n"
-                               " and idx(i+1) < n and idx(i) < idx(i + 1) }");
+    Set *ex_s1 = new Set("{ [i, jp] : i = col(jp)+1 and jp >= 0 and "
+          "idx(i) >= 0 and idx(i+1) >= 0 and col(jp) >= 0 and jp < n and"
+  " col(jp)+2 < n and idx(i) < n and idx(i+1) < n and idx(i) < idx(i + 1) }");
 
    Set *s2;
    // projectOut has the same behaivor for both Relation and Set

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -3952,11 +3952,10 @@ TEST_F(SetRelationTest, projectOut) {
         delete r1;             // removing old r1
         r1 = r2;
     }
+
 //   std::cout << std::endl << "r1 = " << r1->toISLString() << std::endl;
 
    EXPECT_EQ( ex_r1->toISLString() , r1->toISLString() );
-
-
 
     Set *s1 = new Set("{ [i,j,ip,jp] : i = col(jp)+1 and 0 <= i and i < n"
                                      " and idx(i) <= j and j < idx(i+1) }");


### PR DESCRIPTION
Three file added that contain functions to manipulate ISL output strings. These functions can revert the changes that ISL library applies to Tuple Declaration and constraints due to equality in the original constraints.

The main two functions that are added:

revertISLTupDeclToOrig : The main function that restores uninted changes ISL library apply to Tuple Declaration because of the equality constraints. ISL library replaces  tuple variables with their equal expression if one exists in the constraints:
*\*    input to isl   : [n] -> { [i] : i = n and i < 10 }
*\*    output from isl: { [n] : n < 10 }
*\*  This function replaces Tuple Declaration from ISL string with original one,  and creates missing equalities and puts them back into constraints.

projectOutStrCorrection: This function takes in a Set or Relation string and removes tuple variable located in poTv position from Tuple Declaration of the string.
*\*     str         : [n] -> { [i1,i2,i3] : ... }
*\*     poTv        : 1
*\*     correctedStr: [n] -> { [i1,i3] : ... }
