### PR TITLE
adding constant support to TermPartOrdGraph

### DIFF
--- a/src/set_relation/TermPartOrdGraph.cc
+++ b/src/set_relation/TermPartOrdGraph.cc
@@ -191,8 +191,8 @@ void TermPartOrdGraph::doneInsertingTerms() {
         jt++;
         for ( ; jt!=mTerm2IntMap.end(); jt++){
             if( it->first.coefficient() == jt->first.coefficient() ){
-               throw assert_exception( "TermPartOrdGraph::doneInsertingTerms: ERROR"
-                  " more than one instance of unique constant term in parOrdGraph");
+              throw assert_exception( "TermPartOrdGraph::doneInsertingTerms: ERROR"
+               " more than one instance of an unique constant term in parOrdGraph");
             }
             else if( it->first.coefficient() < jt->first.coefficient() ){
                 mGraphPtr->strict( it->second , jt->second );

--- a/src/set_relation/TermPartOrdGraph.h
+++ b/src/set_relation/TermPartOrdGraph.h
@@ -137,13 +137,14 @@ public:
     
     //! Returns a string representation of the class instance for debugging.
     std::string toString() const;        
-        
+
 private:
     int                         mNumTerms;
 
     std::map<UFCallTerm,int>    mUFCallTerm2IntMap;
     std::map<TupleVarTerm,int>  mTupleVarTerm2IntMap;
     std::map<VarTerm,int>       mVarTerm2IntMap;
+    std::map<Term,int>          mTerm2IntMap;
     
     std::set<Term*>             mNonNegativeTerms;
     

--- a/src/set_relation/TermPartOrdGraph_test.cc
+++ b/src/set_relation/TermPartOrdGraph_test.cc
@@ -245,60 +245,83 @@ TEST(TermPartOrdGraphTest, TermPartOrdGraphPartOrd) {
 
 }
 
-
 #pragma mark TermPartOrdGraphConstOrd
 TEST(TermPartOrdGraphTest, TermPartOrdGraphConstOrd) {
+
+    // In this test case we want to show that partial ordering can:
+    //   1. Add orderings between constants (and non-constants) like 1 < 6
+    //   2. Use these ordering to do transitive closures like: 
+    //        ii <= 3 && 6 < ufcall(j)  => ii < ufcall(j)
 
     TermPartOrdGraph g;
     VarTerm * v = new VarTerm( "N" );
     g.insertTerm( v );
     g.termNonNegative( v );
 
-    UFCallTerm* uf_call = new UFCallTerm("tau", 2); // tau(i,j)
+    TupleVarTerm *ii = new TupleVarTerm(1, 0);
+    TupleVarTerm *jj = new TupleVarTerm(1, 1);
+
+    g.insertTerm( ii );
+    g.insertTerm( jj );
+
+    UFCallTerm* uf_call = new UFCallTerm("tau",1); // tau(__tv2)
     Exp *tau_arg_1 = new Exp();
-    tau_arg_1->addTerm(new VarTerm("i"));
+    tau_arg_1->addTerm( new TupleVarTerm(1, 2) );
     uf_call->setParamExp(0,tau_arg_1);
-    Exp *tau_arg_2 = new Exp();
-    tau_arg_2->addTerm(new VarTerm("j"));
-    uf_call->setParamExp(1,tau_arg_2);
 
     g.insertTerm( uf_call );
 
-    Term * c1 = new Term( 1 ); // When we insert a constant like 1, we also insert
-    g.insertTerm( c1 );        // the negative of the constant.
-                               // This is because when we move a term from one side 
-    Term * c2 = new Term( 6 ); // of the in/equality to the other side their coefficient 
-    g.insertTerm( c2 );        // gets multiplied by -1, for non-constant term this is not 
-                               // important since we do not care about their coefficient. 
-                               // However, in case of constants the coefficient is the term itself.
+    Term * c1 = new Term( 3 ); // When we insert a constant like 1, we also 
+    g.insertTerm( c1 );        // insert the negative of the constant. 
+                               // This is because when we move a term from 
+    Term * c2 = new Term( 6 ); // one side of the in/equality to the other side 
+    g.insertTerm( c2 );        // their coefficient gets multiplied by -1, 
+                               // for non-constant term this is not important 
+                               // since we do not care about their coefficient.
+                               // However, in case of constants the coefficient
+                               // is the term itself.
 
-    Term * c3 = new Term( 1 ); // Unique contant terms get inserted only once.
+    Term * c3 = new Term( 3 ); // Unique contant terms get inserted only once.
     g.insertTerm( c3 );        // g would not change.
 
-    Term * c4 = new Term( -6 );
-    g.insertTerm( c4 );        // g would not change.
+    Term * c4 = new Term( -6 );// g would not change, we have already 
+    g.insertTerm( c4 );        // inserted -6 when inserting 6.
 
-    g.doneInsertingTerms();
-    
-    //std::cout << g.toString();
+    g.doneInsertingTerms();    // This will automatically add -6 < -1, -6 < 1, ...
 
+    // Put in relationships between terms
+    g.insertLT( c2 , uf_call );    // 6 < uf_call
+    g.insertLTE(ii , c3 );         // __tv0 <= 3
+    g.insertLTE( c3 , jj );        // 3 <=  __tv1
+
+
+    // __tv0 <= 3 && 6 < uf_call => __tv0 < uf_call(j) ?
+    EXPECT_EQ(true, g.isLT( ii , uf_call ));
+    // __tv0 <= 3 && 3 <= __tv1 => __tv0 <= __tv1 ?
+    EXPECT_EQ(true, g.isLTE( ii , jj ));
+    // 3 < 6 ? 
     EXPECT_EQ(true, g.isLT(c1,c2));
+    // 3 < -6 ?
     EXPECT_EQ(false, g.isLT(c1,c4));
+    // 3 == 3 ?
     EXPECT_EQ(true, g.isEqual(c1,c3));
 
-    EXPECT_EQ("TermPartOrdGraph:\n\tDoneInsertingTerms = 1\n"
-              "\tNumTerms = 6\n\tNonNegativeTerms = \n\t\tN\n\t\t6\n\t\t1\n"
-              "\tUFCallTerm2IntMap = \n\t\tterm = tau(i, j), id = 1"
-              "\n\tTupleVarTerm2IntMap ="
-              " \n\tVarTerm2IntMap = \n\t\tterm = N, id = 0\n\tTerm2IntMap = "
-              "\n\t\tterm = -6, id = 5\n\t\tterm = -1, id = 3\n\t\t"
-              "term = 1, id = 2\n\t\tterm = 6, id = 4\n"
-              "PartOrdGraph:\n\tmN = 6\n\t\t0\t1\t2\t3\t4\t5\n\t"
-              "0\t=\t\t\t\t\t\n\t1\t\t=\t\t\t\t\n\t2\t\t\t=\t\t<\t\n\t"
-              "3\t\t\t<\t=\t<\t\n\t4\t\t\t\t\t=\t\n\t5\t\t\t<\t<\t<\t=\n\n", 
-              g.toString());
+    EXPECT_EQ("TermPartOrdGraph:\n\tDoneInsertingTerms = 1\n\tNumTerms = 8\n"
+                 "\tNonNegativeTerms = \n\t\tN\n\tUFCallTerm2IntMap = \n\t\t"
+                  "term = tau(__tv2), id = 3\n\tTupleVarTerm2IntMap = \n\t\t"
+       "term = __tv0, id = 1\n\t\tterm = __tv1, id = 2\n\tVarTerm2IntMap = "
+      "\n\t\tterm = N, id = 0\n\tTerm2IntMap = \n\t\tterm = -6, id = 7\n\t\t"
+            "term = -3, id = 5\n\t\tterm = 3, id = 4\n\t\tterm = 6, id = 6\n"
+                         "PartOrdGraph:\n\tmN = 8"
+                   "\n\t\t0\t1\t2\t3\t4\t5\t6\t7\n\t0\t=\t\t\t\t\t\t\t\n\t"
+                         "1\t\t=\t<=\t<\t<=\t\t<\t\n\t2\t\t\t=\t\t\t\t\t\n\t"
+                         "3\t\t\t\t=\t\t\t\t\n\t4\t\t\t<=\t<\t=\t\t<\t\n\t"
+                         "5\t\t\t<\t<\t<\t=\t<\t\n\t6\t\t\t\t<\t\t\t=\t\n\t"
+                         "7\t\t\t<\t<\t<\t<\t<\t=\n\n",  g.toString());
     
     delete v;
+    delete ii;
+    delete jj;
     delete uf_call;
     delete c1;
     delete c2;


### PR DESCRIPTION
Added constant support to TermPartOrdGraph:
-- Added a map for Term (constant terms) to the TermPartOrdGraph class.
-- Modified findOrInsertTermId function in this class to handle constant terms.
-- Orderings like 1 < 2 are getting add in doneInsertingTerms function, orderings like i < 2 are getting handles like other orderings.
-- deriveInfo function in VisitorCollectPartOrd class (inside set_relation.cc file) changed to handle constants.
