### PR TITLE
Adding indexUFCs()

### DIFF
--- a/src/set_relation/normalization_test.cc
+++ b/src/set_relation/normalization_test.cc
@@ -385,22 +385,20 @@ TEST_F(NormalizationTest, NestedUFCalls1D2D1D) {
 
 
     r1->normalize();
-    EXPECT_EQ("{ [s, i1, s2, e] : __tv0 - __tv2 = 0 && "
-              "__tv1 - sigma(left(__tv3)[0], left(__tv3)[1]) = 0 "
-              "&& __tv1 >= 0 && "
-              "__tv3 >= 0 && left(__tv3)[0] >= 0 && left(__tv3)[1] >= 0 && "
-              "-__tv1 + N - 1 >= 0 && -__tv3 + K - 1 >= 0 && "
-              "M - left(__tv3)[0] - 1 >= 0 && P - left(__tv3)[1] - 1 >= 0 }",
-              r1->toString());
+    EXPECT_EQ("{ [s, i1, s2, e] : s - s2 = 0 && i1 - sigma(left(e)[0], "
+              "left(e)[1]) = 0 && e >= 0 && left(e)[0] >= 0 && left(e)[1] >= 0 "
+              "&& sigma(left(e)[0], left(e)[1]) >= 0 && -e + K - 1 >= 0 && "
+              "M - left(e)[0] - 1 >= 0 && N - sigma(left(e)[0], "
+              "left(e)[1]) - 1 >= 0 ""&& P - left(e)[1] - 1 >= 0 }",
+              r1->prettyPrintString());
 
     r2->normalize();
-    EXPECT_EQ("{ [s, i1, s, f] : __tv0 - __tv2 = 0 && "
-              "__tv1 - sigma(left(__tv3)[0], left(__tv3)[1]) = 0 "
-              "&& __tv1 >= 0 && "
-              "__tv3 >= 0 && left(__tv3)[0] >= 0 && left(__tv3)[1] >= 0 && "
-              "-__tv1 + N - 1 >= 0 && -__tv3 + K - 1 >= 0 && "
-              "M - left(__tv3)[0] - 1 >= 0 && P - left(__tv3)[1] - 1 >= 0 }",
-              r2->toString());
+    EXPECT_EQ("{ [s, i1, s, f] : s - s = 0 && i1 - sigma(left(f)[0], "
+              "left(f)[1]) = 0 && f >= 0 && left(f)[0] >= 0 && left(f)[1] >= 0 "
+              "&& sigma(left(f)[0], left(f)[1]) >= 0 && -f + K - 1 >= 0 && "
+              "M - left(f)[0] - 1 >= 0 && N - sigma(left(f)[0], "
+              "left(f)[1]) - 1 >= 0 && P - left(f)[1] - 1 >= 0 }",
+              r2->prettyPrintString());
 
     EXPECT_TRUE((*r1) == (*r2));
     

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -413,6 +413,15 @@ public:
     void RemoveExpensiveConsts(std::set<int> parallelTvs, 
                                      int mNumConstsToRemove  );
 
+    /*! Sometimes to provide arguments of an UFC like sigma(a1, a2, ...)
+    **  we use another UFC that is not indexed like left(f). Here, the
+    **  expanded form would look like this: 
+    **                          sigma(left(f)[0], left(f)[1], ...) 
+    **  indexUFCs() would create the expanded format for normalization purposes.
+    */
+    void indexUFCs();
+
+
 // FIXME: what methods should we have to iterate over conjunctions so
 // this can go back to protected?
 //protected:

--- a/src/util/PartOrdGraph.cc
+++ b/src/util/PartOrdGraph.cc
@@ -45,8 +45,8 @@ PartOrdGraph::PartOrdGraph(unsigned int N) {
     this->mN = N;
     this->mAdjacencyMatrix = new CompareEnum[N*N];
     // Initialize all 
-    for (int i=0; i<N; i++) {
-        for (int j=0; j<N; j++) {
+    for (unsigned int i=0; i<N; i++) {
+        for (unsigned int j=0; j<N; j++) {
             mAdjacencyMatrix[getIndex(i,j)] = NO_ORD;
             if (i==j) {
                 mAdjacencyMatrix[getIndex(i,j)] = EQUAL;
@@ -64,8 +64,8 @@ PartOrdGraph::PartOrdGraph(const PartOrdGraph& other) {
 PartOrdGraph& PartOrdGraph::operator=(const PartOrdGraph& other) {
     mN = other.mN;
     this->mAdjacencyMatrix = new CompareEnum[mN*mN];
-    for (int i=0; i<mN; i++) {
-        for (int j=0; j<mN; j++) {
+    for (unsigned int i=0; i<mN; i++) {
+        for (unsigned int j=0; j<mN; j++) {
             mAdjacencyMatrix[getIndex(i,j)]
                 = other.mAdjacencyMatrix[getIndex(i,j)];
         }
@@ -209,14 +209,14 @@ std::string PartOrdGraph::toString() {
     ss << "PartOrdGraph:\n\tmN = " << this->mN << std::endl;
     // column headers
     ss << "\t";
-    for (int j=0; j<this->mN; j++) {
+    for (unsigned int j=0; j<this->mN; j++) {
         ss << "\t" << j;
     }
     ss << std::endl;
     // rows in adjacency matrix
-    for (int i=0; i<this->mN; i++) {
+    for (unsigned int i=0; i<this->mN; i++) {
         ss << "\t" << i;
-        for (int j=0; j<this->mN; j++) {
+        for (unsigned int j=0; j<this->mN; j++) {
             ss << "\t";
             if (isStrict(i,j)) { ss << "<"; }
             if (isNonStrict(i,j)) { ss << "<="; }


### PR DESCRIPTION
The test case "NormalizationTest.NestedUFCalls1D2D1D" is the only failing test case in current version of IEGenLib. The old normalize() function was doing some functionality related to non-index function that new normalize is not doing. This pull request fixes the failing test by adding indexUFCs() function, the description of its functionality is as follow:

Sometimes to provide arguments of an UFC like sigma(a1, a2, ...), we use another UFC that is not indexed like left(f). Here, the  expanded form would look like this: 
       sigma(left(f)[0], left(f)[1], ...) 
In this pull request I have added indexUFCs() function to SparseConstraint class that creates the expanded format for normalization purposes. This function gets called at the begging of normalize() function.

In this pull request, I have also fixed warnings that were related to compression between signed and unsigned integers, all of which were located in PartOrdGraph.cc. Now, there are few remaining warnings that I am going to look into, it might take a bit of work fix them.