### PR TITLE
Pull Request for Restrict Operation

### DIFF
--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -197,7 +197,7 @@ void Conjunction::reset() {
 //! as a set.
 //! r = { x -> y : C }
 //! s = { z : D }
-//! r(s) = { z -> y : D && C[z/x]  }
+//! r(s) = { x -> y : D && C[x/z]  }
 //! \param rhs
 //! \return
 Conjunction *Conjunction::Restrict(const Conjunction *rhs) const {
@@ -213,6 +213,9 @@ Conjunction *Conjunction::Restrict(const Conjunction *rhs) const {
          i != rhs->mInequalities.end(); i++ ) {
         retval->addInequality((*i)->clone());
     }
+
+
+
     return retval;
 }
 
@@ -2275,13 +2278,6 @@ Relation * Relation::Restrict(const Set *rhs) const {
     Relation * retVal = new Relation(setArity,relOutArity);
 
 
-    // rhs tuple Decl = [a,b], lhs tuple Decl = [i,j] -> [n] = [i,j,n]
-    // Result tuple input declaration should be sets tuple
-    // declaration. Result tuple Decl = [a,b] -> [n] = [a,b,n].
-    TupleDecl tupleDecl = this->getTupleDecl();
-    for(int i =0; i < setArity ; i++){
-        tupleDecl.copyTupleElem(rhs->getTupleDecl(),i,i);
-    }
 
     // Have to do cross product restrict in both sets.
     for(std::list<Conjunction*>::const_iterator it =
@@ -2290,7 +2286,6 @@ Relation * Relation::Restrict(const Set *rhs) const {
                 rhs->conjunctionBegin(); it2 != rhs->conjunctionEnd(); it2++) {
             Conjunction * conj = (*it)->Restrict(*it2);
             if (conj){
-                conj->setTupleDecl(tupleDecl);
                 retVal->addConjunction(conj);
             }else{
                 throw assert_exception("Relation::Restrict: failed in conjunction");

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -2265,8 +2265,8 @@ Relation* Relation::Intersect(const Relation* rhs) const{
    * Relation which the caller is responsible for
    * deallocating
    *  r = { x -> y : C }
-   * s = { z : D }
-   *  r \ s  = { x -> y : D[x/z] && C  }
+   *  s = { z : D }
+   *  r \ s  = { x -> y : D[z/x] && C  }
    *
    * @param rhs
    * @return

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -198,7 +198,7 @@ void Conjunction::reset() {
 //! r = { x -> y : C }
 //! s = { z : D }
 //! r(s) = { x -> y : D && C[x/z]  }
-//! \param rh dependentStack.top();s
+//! \param rhs
 //! \return
 Conjunction *Conjunction::Restrict(const Conjunction *rhs) const {
     // copy in all of the constraints from ourselves

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -195,9 +195,11 @@ void Conjunction::reset() {
 
 //! Restrict this (interpreted as a Relation) to rhs, which is interpreted
 //! as a set.
+//! Returns a new conjunction which the caller is responsible for
+//! deallocating.
 //! r = { x -> y : C }
 //! s = { z : D }
-//! r(s) = { x -> y : D && C[x/z]  }
+//! r \ s  = { x -> y : D[x/z] && C  }
 //! \param rhs
 //! \return
 Conjunction *Conjunction::Restrict(const Conjunction *rhs) const {

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -198,7 +198,7 @@ void Conjunction::reset() {
 //! r = { x -> y : C }
 //! s = { z : D }
 //! r(s) = { x -> y : D && C[x/z]  }
-//! \param rhs
+//! \param rh dependentStack.top();s
 //! \return
 Conjunction *Conjunction::Restrict(const Conjunction *rhs) const {
     // copy in all of the constraints from ourselves
@@ -2259,13 +2259,15 @@ Relation* Relation::Intersect(const Relation* rhs) const{
 }
 
 /*!
- * Restrict a set with a relation. Returns a new
- * Relation which the caller is responsible for
- * deallocating
- *
- * @param rhs
- * @return
- */
+   * Restrict a set with a relation. Returns a new
+   * Relation which the caller is responsible for
+   * deallocating
+   *  r = { x -> y : C }
+   * s = { z : D }
+   *  r(s) = { x -> y : D && C[x/z]  }
+   * @param rhs
+   * @return
+   */
 Relation * Relation::Restrict(const Set *rhs) const {
     int setArity = rhs->arity();
     int relInArity = this->inArity();

--- a/src/set_relation/set_relation.cc
+++ b/src/set_relation/set_relation.cc
@@ -2264,7 +2264,8 @@ Relation* Relation::Intersect(const Relation* rhs) const{
    * deallocating
    *  r = { x -> y : C }
    * s = { z : D }
-   *  r(s) = { x -> y : D && C[x/z]  }
+   *  r \ s  = { x -> y : D[x/z] && C  }
+   *
    * @param rhs
    * @return
    */

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -729,10 +729,10 @@ public:
     ** deallocating
     **  r = { x -> y : C }
     ** s = { z : D }
-    **  r \ s  = { x -> y : D[x/z] && C  }
+    **  r \ s  = { x -> y : D[z/x] && C  }
     **
     ** @param rhs
-    *# @return
+    ** @return
     */
 
     Relation * Restrict (const Set* rhs) const;

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -725,6 +725,9 @@ public:
      * Restrict a set with a relation. Returns a new
      * Relation which the caller is responsible for
      * deallocating
+     *  r = { x -> y : C }
+     * s = { z : D }
+     *  r(s) = { x -> y : D && C[x/z]  }
      * @param rhs
      * @return
      */

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -202,7 +202,7 @@ public:
     //! as a set.
     //! r = { x -> y : C }
     //! s = { z : D }
-    //! r(s) = { z -> y : D && C[z/x]  }
+    //! r(s) = { x -> y : D && C[x/z]  }
     //! \param rhs
     //! \return
     Conjunction* Restrict (const Conjunction* rhs) const;

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -200,9 +200,11 @@ public:
 
     //! Restrict this (interpreted as a Relation) to rhs, which is interpreted
     //! as a set.
+    //! Returns a new conjunction which the caller is responsible for
+    //! deallocating.
     //! r = { x -> y : C }
     //! s = { z : D }
-    //! r(s) = { x -> y : D && C[x/z]  }
+    //! r \ s  = { x -> y : D[x/z] && C  }
     //! \param rhs
     //! \return
     Conjunction* Restrict (const Conjunction* rhs) const;
@@ -730,7 +732,7 @@ public:
     **  r \ s  = { x -> y : D[x/z] && C  }
     **
     ** @param rhs
-    ** @return
+    *# @return
     */
 
     Relation * Restrict (const Set* rhs) const;

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -176,6 +176,10 @@ public:
     //! \param innerArity
     Conjunction *Compose(const Conjunction *rhs, int innerArity) const;
 
+
+
+
+
     //! Apply this (interpreted as a Relation) to rhs, which is interpreted
     //! as a set.
     //! r = { x -> y : x = G(y) && C }
@@ -193,6 +197,15 @@ public:
     ** \param rhs (not adopted)
     */
     Conjunction* Intersect(const Conjunction* rhs) const;
+
+    //! Restrict this (interpreted as a Relation) to rhs, which is interpreted
+    //! as a set.
+    //! r = { x -> y : C }
+    //! s = { z : D }
+    //! r(s) = { z -> y : D && C[z/x]  }
+    //! \param rhs
+    //! \return
+    Conjunction* Restrict (const Conjunction* rhs) const;
 
     /*! Treating this Conjunction like a domain or range.  Creates
     ** a new set where passed in tuple expression is
@@ -707,6 +720,15 @@ public:
     ** \param rhs (not adopted)
     */
     Relation *Intersect(const Relation* rhs) const;
+
+    /*!
+     * Restrict a set with a relation. Returns a new
+     * Relation which the caller is responsible for
+     * deallocating
+     * @param rhs
+     * @return
+     */
+    Relation * Restrict (const Set* rhs) const;
 
     /*! Create the inverse of this relation. Returns a new Relation,
     **    which the caller is responsible for deallocating.

--- a/src/set_relation/set_relation.h
+++ b/src/set_relation/set_relation.h
@@ -722,15 +722,17 @@ public:
     Relation *Intersect(const Relation* rhs) const;
 
     /*!
-     * Restrict a set with a relation. Returns a new
-     * Relation which the caller is responsible for
-     * deallocating
-     *  r = { x -> y : C }
-     * s = { z : D }
-     *  r(s) = { x -> y : D && C[x/z]  }
-     * @param rhs
-     * @return
-     */
+    ** Restrict a set with a relation. Returns a new
+    ** Relation which the caller is responsible for
+    ** deallocating
+    **  r = { x -> y : C }
+    ** s = { z : D }
+    **  r \ s  = { x -> y : D[x/z] && C  }
+    **
+    ** @param rhs
+    ** @return
+    */
+
     Relation * Restrict (const Set* rhs) const;
 
     /*! Create the inverse of this relation. Returns a new Relation,

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -4417,17 +4417,24 @@ TEST_F(SetRelationTest, getZ3form){
 TEST_F(SetRelationTest, RestrictDomainTest){
 
     // Test with valid Relation and Set.
+    // rel = { [l] -> [k] : 1 <= n && n <= 10 && k = n + 1 }
+    // set = { [i]: 5 <= i && i <= 25 }
+    // expected result
+    // rel \ set = { [l] -> [k] : 1 <= n && n <= 10 && k = n + 1 && 5 <= i && i <= 25}
     Relation *rel = new Relation("{[l] -> [k]: 1 <= n and n <= 10 and k = n + 1}");
     Set * set = new Set("{[i]: 5 <= i and i <= 25}");
     Relation * restrictRel = rel->Restrict(set);
 
-    EXPECT_EQ( "{ [l] -> [k] : __tv1 - n - 1 = 0"
-               " && -__tv0 + 25 >= 0 && __tv0 - 5 >= 0"
-               " && -n + 10 >= 0 && n - 1 >= 0 }",
-               restrictRel->toString());
+    EXPECT_EQ( "{ [l] -> [k] : k - n - 1 = 0"
+               " && -l + 25 >= 0 && l - 5 >= 0 &&"
+               " -n + 10 >= 0 && n - 1 >= 0 }",
+               restrictRel->prettyPrintString());
 
     // Test with valid relation and set.
-
+    // rel = { [i] -> [k] : 1 < k && i = 0}
+    // set = { [i]: n < 10 }
+    // expected result
+    // rel \ set = { [i] -> [k] : 1 < k && i = 10 && n < 10}
     Relation * rel3 = new Relation("{[i]->[k]: i < k and i =0}");
     Set * set3 = new Set("{[i]: n < 10}");
     Relation * restrictRel3 = rel3->Restrict(set3);
@@ -4435,7 +4442,7 @@ TEST_F(SetRelationTest, RestrictDomainTest){
               " -n + 9 >= 0 && -i + k - 1 >= 0 }",restrictRel3->prettyPrintString());
 
 
-    // Test with Dense -> COO example.
+
      auto set1 = new Set("{[i,j]: i >= 0 and i < NR and"
                           " j >= 0 and j < NC and Ad(i,j) > 0}");
      auto rel1 = new Relation("{[i,j] -> [n]:"

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -1,19 +1,20 @@
- /* file set_relation_test.cc
- *
- * \brief Set and Relation tests.
- *
- * This file is to test all of the Set and Relation classes, along with the
- * related Conjunction class.
- *
- * \date Started: 3/28/12
- *
- * \authors Michelle Strout, Joseph Strout, Mahdi Soltan Mohammadi
- *
- * Copyright (c) 2012, 2013 Colorado State University <br>
- * Copyright (c) 2015-2016, University of Arizona <br>
- * All rights reserved. <br>
- * See ../../COPYING for details. <br>
- */
+/*!
+* \file set_relation_test.cc
+*
+* \brief Set and Relation tests.
+*
+* This file is to test all of the Set and Relation classes, along with the
+* related Conjunction class.
+*
+* \date Started: 3/28/12
+*
+* \authors Michelle Strout, Joseph Strout, Mahdi Soltan Mohammadi
+*
+* Copyright (c) 2012, 2013 Colorado State University <br>
+* Copyright (c) 2015-2016, University of Arizona <br>
+* All rights reserved. <br>
+* See ../../COPYING for details. <br>
+*/
 
 #include "set_relation.h"
 #include "expression.h"
@@ -4414,6 +4415,8 @@ TEST_F(SetRelationTest, getZ3form){
 // Test restrict operations.
 
 TEST_F(SetRelationTest, RestrictDomainTest){
+
+    // Test with valid Relation and Set.
     Relation *rel = new Relation("{[l] -> [k]: 1 <= n and n <= 10 and k = n + 1}");
     Set * set = new Set("{[i]: 5 <= i and i <= 25}");
     Relation * restrictRel = rel->Restrict(set);
@@ -4423,6 +4426,16 @@ TEST_F(SetRelationTest, RestrictDomainTest){
                " && -n + 10 >= 0 && n - 1 >= 0 }",
                restrictRel->toString());
 
+    // Test with valid relation and set.
+
+    Relation * rel3 = new Relation("{[i]->[k]: i < k and i =0}");
+    Set * set3 = new Set("{[i]: n < 10}");
+    Relation * restrictRel3 = rel3->Restrict(set3);
+    EXPECT_EQ("{ [i] -> [k] : i = 0 &&"
+              " -n + 9 >= 0 && -i + k - 1 >= 0 }",restrictRel3->prettyPrintString());
+
+
+    // Test with Dense -> COO example.
      auto set1 = new Set("{[i,j]: i >= 0 and i < NR and"
                           " j >= 0 and j < NC and Ad(i,j) > 0}");
      auto rel1 = new Relation("{[i,j] -> [n]:"
@@ -4435,16 +4448,23 @@ TEST_F(SetRelationTest, RestrictDomainTest){
                prettyPrintString());
 
 
-     Relation *rel2 = new Relation("{[l] -> [k]: 1 <= i and i <= 10 and k = i + 1}");
-     Set * set2 = new Set("{[i,l]: 5 <= i and i <= 25 and l = row(i)}");
+     // Test with Relation and set with mismatched arities.
+     Relation *rel2 = new Relation(
+             "{[l] -> [k]: 1 <= i and i <= 10 and k = i + 1}");
+     Set * set2 = new Set(
+             "{[i,l]: 5 <= i and i <= 25 and l = row(i)}");
 
-     // expect exception
-     EXPECT_ANY_THROW(rel2->Restrict(set2));
+     // Expect exception about arity mismatch.
+     EXPECT_THROW(rel2->Restrict(set2),
+                  iegenlib::assert_exception );
 
      delete restrictRel;
      delete rel1;
      delete rel2;
+     delete rel3;
      delete set1;
      delete set2;
+     delete set3;
      delete restrictRel2;
+     delete restrictRel3;
 }

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -4414,13 +4414,13 @@ TEST_F(SetRelationTest, getZ3form){
 // Test restrict operations.
 
 TEST_F(SetRelationTest, RestrictDomainTest){
-    Relation *rel = new Relation("{[l] -> [k]: 1 <= i and i <= 10 and k = i + 1}");
+    Relation *rel = new Relation("{[l] -> [k]: 1 <= n and n <= 10 and k = n + 1}");
     Set * set = new Set("{[i]: 5 <= i and i <= 25}");
     Relation * restrictRel = rel->Restrict(set);
 
-    EXPECT_EQ( "{ [l] -> [k] : __tv1 - i - 1 = 0 && -__tv0"
-               " + 25 >= 0 && __tv0 - 5 >= 0 && -i + 10"
-               " >= 0 && i - 1 >= 0 }",
+    EXPECT_EQ( "{ [l] -> [k] : __tv1 - n - 1 = 0"
+               " && -__tv0 + 25 >= 0 && __tv0 - 5 >= 0"
+               " && -n + 10 >= 0 && n - 1 >= 0 }",
                restrictRel->toString());
 
      auto set1 = new Set("{[i,j]: i >= 0 and i < NR and"

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -4418,9 +4418,10 @@ TEST_F(SetRelationTest, RestrictDomainTest){
     Set * set = new Set("{[i]: 5 <= i and i <= 25}");
     Relation * restrictRel = rel->Restrict(set);
 
-    EXPECT_EQ( "{ [i] -> [k] : k - i - 1 = 0 && -i + 25 >= 0 && "
-               "i - 5 >= 0 && -i + 10 >= 0 && i - 1 >= 0 }",
-               restrictRel->prettyPrintString());
+    EXPECT_EQ( "{ [l] -> [k] : __tv1 - i - 1 = 0 && -__tv0"
+               " + 25 >= 0 && __tv0 - 5 >= 0 && -i + 10"
+               " >= 0 && i - 1 >= 0 }",
+               restrictRel->toString());
 
      auto set1 = new Set("{[i,j]: i >= 0 and i < NR and"
                           " j >= 0 and j < NC and Ad(i,j) > 0}");

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -4433,6 +4433,17 @@ TEST_F(SetRelationTest, RestrictDomainTest){
                " - 1 >= 0 && -j + NC - 1 >= 0 }",restrictRel2->
                prettyPrintString());
 
+
+     Relation *rel2 = new Relation("{[l] -> [k]: 1 <= i and i <= 10 and k = i + 1}");
+     Set * set2 = new Set("{[i,l]: 5 <= i and i <= 25 and l = row(i)}");
+
+     // expect exception
+     EXPECT_ANY_THROW(rel2->Restrict(set2));
+
      delete restrictRel;
+     delete rel1;
+     delete rel2;
+     delete set1;
+     delete set2;
      delete restrictRel2;
 }

--- a/src/set_relation/set_relation_test.cc
+++ b/src/set_relation/set_relation_test.cc
@@ -1,5 +1,4 @@
-/*!
- * \file set_relation_test.cc
+ /* file set_relation_test.cc
  *
  * \brief Set and Relation tests.
  *
@@ -2408,6 +2407,8 @@ TEST_F(SetRelationTest, SetIntersect) {
 }
 */
 
+
+
 #pragma mark SetTupleIterator
 // Checking that get all tuple variables in correct order.
 TEST_F(SetRelationTest, SetTupleIterator) {
@@ -4410,4 +4411,28 @@ TEST_F(SetRelationTest, getZ3form){
 
    delete s1;
 }
+// Test restrict operations.
 
+TEST_F(SetRelationTest, RestrictDomainTest){
+    Relation *rel = new Relation("{[l] -> [k]: 1 <= i and i <= 10 and k = i + 1}");
+    Set * set = new Set("{[i]: 5 <= i and i <= 25}");
+    Relation * restrictRel = rel->Restrict(set);
+
+    EXPECT_EQ( "{ [i] -> [k] : k - i - 1 = 0 && -i + 25 >= 0 && "
+               "i - 5 >= 0 && -i + 10 >= 0 && i - 1 >= 0 }",
+               restrictRel->prettyPrintString());
+
+     auto set1 = new Set("{[i,j]: i >= 0 and i < NR and"
+                          " j >= 0 and j < NC and Ad(i,j) > 0}");
+     auto rel1 = new Relation("{[i,j] -> [n]:"
+                                    " row(n) = i and col(n) = j and  i >= 0 and "
+                                    " i < NR and j >= 0 and j < NC}");
+     Relation* restrictRel2 = rel1->Restrict(set1);
+     EXPECT_EQ("{ [i, j] -> [n] : i - row(n) = 0 && j - col(n) = 0"
+               " && i >= 0 && j >= 0 && Ad(i, j) - 1 >= 0 && -i + NR"
+               " - 1 >= 0 && -j + NC - 1 >= 0 }",restrictRel2->
+               prettyPrintString());
+
+     delete restrictRel;
+     delete restrictRel2;
+}


### PR DESCRIPTION
Pull Request for Restrict Operation in IEGENLib

A restrict operation when applied to a set performs the following:
```
   r = { x -> y : C }
   s = { z : D }
   r(s) = { x -> y : D && C[x/z]  }
```

In this operation, a relation is restricted by a set's constraint. This means that additional constraints are added to the relation from the set.

This operation requires that the input arity of the relation and the arity of the set be the same.

Sample test cases can be found in set_relation_test.cc, SetRelationTest.RestrictDomainTest